### PR TITLE
fix(ui): 修复子目录下页面无法正确显示网站图标 (favicon) 的问题

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" href="favicon.ico">
+<link rel="shortcut icon" href="/favicon.ico">


### PR DESCRIPTION
目前，hmcl帮助文档网站
- 当页面为主页面或在url根路径下的页面可以正常显示图标
- 当页面为任何子目录下的页面则不能显示图标，比如[光影](https://docs.hmcl.net/launcher/shader.html)  

此PR修复了这个问题，将加载网站图标的链接从相对路径改为根路径