### PR TITLE
构建时使用 `JEKYLL_ENV=production` 环境变量

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,8 @@ clone:
 steps:
 - name: build
   image: jekyll/jekyll:4.2.2
+  environment:
+    JEKYLL_ENV: production
   commands:
     - touch Gemfile.lock
     - chmod a+w Gemfile.lock


### PR DESCRIPTION
构建时使用 `JEKYLL_ENV=production` 环境变量

https://jekyllrb.com/docs/configuration/environments/

用于修复 hits 未被渲染的问题。

```
{% if jekyll.environment == 'production' and page.hits %}
<img src="https://hits.zkitefly.eu.org/?tag={{ page.url | absolute_url | url_encode }}" alt="Hits" decoding="async">
{% endif %}
```