### PR TITLE
支持 html sass 产物压缩

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -117,8 +117,12 @@ permalink: /:categories/:title/
 
 compress_html:
   clippings: all
+  comments: all
   ignore:
     envs: development
+
+sass:
+  style: compressed
 
 head_scripts:
   - /assets/js/theme.js

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,37 @@
+---
+layout: compress
+---
+
+<!doctype html>
+{% include copyright.html %}
+<html lang="{{ site.locale | replace: "_", "-" | default: "en" }}" class="no-js">
+  <head>
+    {% include head.html %}
+    {% include head/custom.html %}
+  </head>
+
+  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{% if site.rtl %}rtl{% else %}ltr{% endif %}">
+    {% include_cached skip-links.html %}
+    {% include_cached masthead.html %}
+
+    <div class="initial-content">
+      {{ content }}
+      {% include after-content.html %}
+    </div>
+
+    {% if site.search == true %}
+      <div class="search-content">
+        {% include_cached search/search_form.html %}
+      </div>
+    {% endif %}
+
+    <div id="footer" class="page__footer">
+      <footer>
+        {% include footer/custom.html %}
+        {% include_cached footer.html %}
+      </footer>
+    </div>
+
+    {% include scripts.html %}
+  </body>
+</html>


### PR DESCRIPTION
- 启用 html 压缩，如压缩导致意外情况可以在页面 front-matter 添加 `compress_html: false` 以禁用
  https://jch.penibelst.de/
- 启用 sass 压缩