### PR TITLE
更新站点描述信息

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -150,7 +150,7 @@ title: HMCL 文档
 # title_separator: -
 # subtitle:
 # name: ""
-description: HMCL 启动器 | 跨平台 | 整合包管理 | 自动安装 | 八年历史 | 三亿次使用
+description: HMCL 启动器 | 跨平台 | 整合包管理 | 自动安装 | 十二年历史 | 三亿次使用
 url: https://docs.hmcl.net
 # repository:
 # teaser:


### PR DESCRIPTION
根据 https://web.archive.org/web/20130804094916/http://www.mcbbs.net/thread-142335-1-1.html 所示，文章发帖时间为 `2013-7-13 23:14:54` 因此判断距今应有至少十二年历史，这也与 https://hmcl.huangyuhui.net 所述一致。

> 如果确定是 13 年首次发布的话，`footer.since` 也可以考虑设置为 2013
