### PR TITLE
移除一些无用插件

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,11 +15,7 @@ group :jekyll_plugins do
   gem "jekyll-sitemap", "1.4.0"
   gem "jekyll-gist", "1.5.0"
   gem "jekyll-feed", "0.17.0"
-  gem "jemoji", "0.13.0"
   gem "jekyll-include-cache", "0.2.1"
-  gem "jekyll-algolia", "1.7.1"
-  gem "jekyll-archives", "2.3.0"
-  gem "jekyll-seo-tag", "2.8.0"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/_config.yml
+++ b/_config.yml
@@ -66,9 +66,6 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jekyll-include-cache
-  - jemoji
-  - jekyll-archives
-  - jekyll-seo-tag
 # minimal-mistakes (mimic GitHub Pages with --safe)
 # whitelist:
 #   - jekyll-paginate


### PR DESCRIPTION
- jemoji 用于渲染 github 表情，目前站点不存在使用 github 表情的文章且渲染的表情符号依赖 github 服务器，部分地区可能存在访问性问题。
- jekyll-algolia 用于站点搜索，目前站点未开启搜索且该搜索功能需要配置三方 api。
- jekyll-archives 用于归档文章 `post` 的，主要针对文章的发布时间、分类及标签进行文章归档，当前站点不能存在基于 post 的文档。
- jekyll-seo-tag 用于添加一些 seo 信息，当前并未启用。