### PR TITLE
支持为 PR 生成预览构建

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -203,6 +203,7 @@ jobs:
         with:
           ruby-version: "3.4"
           bundler-cache: true
+          cache-version: pr${{ env.GITHUB_PR_NUMBER }}
       - name: Jekyll Build
         run: |
           echo "url: https://${{ needs.preview-create-init.outputs.domain }}" > _action.yml


### PR DESCRIPTION
# 支持为 PR 生成预览构建

> [!NOTE]
> 欢迎大家测试并提供反馈！

## 关联 ISSUE

- #307

## 功能

### 创建预览

仓库所属组织的成员和仓库所有者在需要创建预览的 PR 添加 `/preview create` 评论或者添加 `preview/create` 标签触发 Github Action 工作流创建 PR 预览。

### 移除预览

> [!NOTE]
> 移除预览仅删除缓存中当前 PR 产生的构建文件，因此在 Github Pages 下次构建成功前页面仍可访问。

仓库所属组织的成员和仓库所有者在需要移除预览的 PR 添加 `/preview remove` 评论或添加 `preview/remove` 标签也可以关闭 PR 触发 Github Action 工作流移除 PR 预览。

## 存在的问题

- jekyll 支持插件机制，插件可能在构建过程中造成破坏性操作，故可能存在安全问题
  - 为提升安全性，目前构建步骤在最低权限环境下运行，并且构建必须手动触发
- 产物中部分文章存在路径错误（需要对文章路径进行特殊处理）
  - 需要对文章中的相对链接做特殊处理，例如使用 `{{ /path | relative_url }}` 或者 `{% link _docs/xxxx.md %}`
