### PR TITLE
尝试使用 `host.docker.internal` 克隆

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,12 +10,11 @@ steps:
   image: ruby:3.4
   environment:
     JEKYLL_ENV: production
-    BUNDLE_PATH: vendor/bundle
+    BUNDLE_PATH: /drone/src/vendor/bundle
   commands:
     - "git -c http.sslVerify=false -c http.extraHeader=\"Host: git.hmcl.net\" clone --branch main --depth 1 https://host.docker.internal/huanghongxun/HMCL-docs.git HMCL-docs"
     - cd HMCL-docs
     - bundle config mirror.https://rubygems.org https://mirrors.cloud.tencent.com/rubygems
-    - bundle config path /drone/src/vendor/bundle
     - bundle install --verbose
     - echo "cache_dir: /drone/src/.jekyll-cache" > /drone/src/_cache_config.yml
     - bundle exec jekyll build --trace --verbose --destination /drone/src/_site --config /drone/src/HMCL-docs/_config.yml,/drone/src/_cache_config.yml


### PR DESCRIPTION
根据 drone gitea 返回响应头二者均部署在 nginx 上，且 DNS 解析地址均指向同一个 IP 故猜测二者可能部署在同一台服务器上，但是构建流程中 clone 时间非常异常，甚至远超从远程克隆的时间。因此，尝试通过 docker 内置的 `host.docker.internal` 强制使用宿主机 IP 进行克隆。