### PR TITLE
仅在监听模式下启用 ruby 缓存

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -12,7 +12,7 @@ env:
   JEKYLL_ENV: production
 jobs:
   preview-remove:
-    if: >-
+    if:
       ${{
         !github.event.repository.fork && (
           ( github.event_name == 'pull_request_target' && (
@@ -119,7 +119,7 @@ jobs:
               name: "preview/watch"
             });
   preview-create-init:
-    if: >-
+    if:
       ${{
         !github.event.repository.fork && (
           ( github.event_name == 'pull_request_target' && (
@@ -189,6 +189,15 @@ jobs:
   preview-create-build:
     needs: preview-create-init
     runs-on: ubuntu-latest
+    env:
+      PREVIEW_WATCH:
+        ${{
+          contains(github.event.pull_request.labels.*.name, 'preview/watch') ||
+          contains(github.event.issue.labels.*.name, 'preview/watch') || (
+            github.event_name == 'issue_comment' &&
+            github.event.comment.body == '/preview watch'
+          )
+        }}
     outputs:
       artifact-id: ${{ steps.upload-site.outputs.artifact-id }}
     steps:
@@ -207,15 +216,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
-          bundler-cache: >-
-            ${{
-              contains(github.event.pull_request.labels.*.name, 'preview/watch') ||
-              contains(github.event.issue.labels.*.name, 'preview/watch') || (
-                github.event_name == 'issue_comment' &&
-                github.event.comment.body == '/preview watch'
-              )
-            }}
-          cache-version: pr${{ env.GITHUB_PR_NUMBER }}
+          bundler-cache: ${{ env.PREVIEW_WATCH }}
+          cache-version: PR-${{ env.GITHUB_PR_NUMBER }}
       - name: Jekyll Build
         run: |
           echo "url: https://${{ needs.preview-create-init.outputs.domain }}" > _action.yml
@@ -224,6 +226,7 @@ jobs:
           echo "destination: /home/runner/site" >> _action.yml
           echo "preview:" >> _action.yml
           echo "  pr-number: ${{ env.GITHUB_PR_NUMBER }}" >> _action.yml
+          ${{ env.PREVIEW_WATCH }} || bundle install --jobs 4
           bundle exec jekyll build --config _config.yml,_action.yml
       - id: upload-site
         name: Upload Site


### PR DESCRIPTION
出于安全考虑，PR 预览会对不同 PR 的 Ruby 缓存进行隔离。鉴于该缓存对构建速度提升有限，且为避免缓存体积过大，现仅在监听模式下启用 Ruby 缓存。

> [使用限制和收回政策](https://docs.github.com/zh/actions/reference/workflows-and-actions/dependency-caching#usage-limits-and-eviction-policy)
GitHub 将删除 7 天内未被访问的任何缓存条目。 可以存储的缓存数没有限制，但仓库中所有缓存的总大小有限为 10 GB。 仓库达到其最大缓存存储后，缓存逐出策略将按照上次访问时间的顺序，从最早到最近，依次删除缓存以释放空间。
> 如果超过此限制，GitHub 将保存新缓存，但会开始收回缓存，直到总大小小于存储库限制。缓存逐出过程可能会导致缓存抖动，即频繁地创建和删除缓存。 若要减少这种情况，可以查看存储库缓存并采取纠正措施，例如从特定工作流中删除缓存。 请参阅 [管理缓存](https://docs.github.com/zh/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manage-caches)。