### PR TITLE
支持刷新缓存

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,7 +1,7 @@
 name: PR Preview
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 */6 * *
   issue_comment:
     types: [created]
   pull_request_target:
@@ -14,7 +14,7 @@ env:
   JEKYLL_ENV: production
 jobs:
   cache-refresh:
-    if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 0 * * *' }}
+    if: ${{ !github.event.repository.fork && github.event_name == 'schedule' && github.event.schedule == '0 0 */6 * *' }}
     runs-on: ubuntu-latest
     steps:
       - name: Cache Refresh


### PR DESCRIPTION
为避免因 GitHub 缓存限制（7 天有效期）导致存储在缓存中的构建产物丢失，现支持定时和手动刷新缓存功能。

1. 每日 UTC 时间 0 点自动刷新缓存
2. 提供手动刷新缓存的功能