### PR TITLE
修改自动链接的判断逻辑

### DIFF
--- a/_plugins/auto-link.rb
+++ b/_plugins/auto-link.rb
@@ -5,24 +5,23 @@ Jekyll::Hooks.register [:pages, :documents], :post_convert do |doc|
   next unless doc.output_ext == ".html"
 
   site = doc.site
-  baseurl = site.config["baseurl"].to_s
   liquid_context = Liquid::Context.new({}, {}, { site: site })
 
   process_uri = lambda do |path|
     uri = Addressable::URI.parse(path)
-    if uri&.path && !uri.path&.start_with?(baseurl)
+    if uri&.path
       uri.path = Liquid::Template.parse("{% link #{uri.path[1..]} %}").render!(liquid_context)
     end
     uri.to_s
   end
 
   fragment = Nokogiri::HTML::DocumentFragment.parse(doc.content)
-  fragment.css("[src^=\"/\"]").each do |item|
+  fragment.css("[src^=\"/assets/\"],[src^=\"/\"][src$=\".md\"],[src^=\"/\"][src*=\".md#\"]").each do |item|
     if item["src"]
       item["src"] = process_uri.call(item["src"])
     end
   end
-  fragment.css("[href^=\"/\"]").each do |item|
+  fragment.css("[href^=\"/assets/\"],[href^=\"/\"][href$=\".md\"],[href^=\"/\"][href*=\".md#\"]").each do |item|
     if item["href"]
       item["href"] = process_uri.call(item["href"])
     end


### PR DESCRIPTION
现在不再依赖 `baseurl` 前缀判断是否需要自动转换链接，插件将处理以下三类链接：

1. 以 /assets/ 开头的
2. 以 / 开头并以 .md 结尾的
3. 以 / 开头且包含 .md# 的

> 使用 `baseurl` 来判断是否需要自动转换链接并不可靠，例如当 `baseurl` 为空时，会导致所有链接都无法进行自动链接处理。
> https://docs.hmcl.net/faq.html

Fixes #338
