### PR TITLE
使用 `jekyll-redirect-from` 处理快照更新的跳转

### DIFF
--- a/_downloads/hmcl-snapshot-update.md
+++ b/_downloads/hmcl-snapshot-update.md
@@ -1,22 +1,4 @@
 ---
 title: 下载 HMCL-Snapshot 版本
-date: 2024-01-09 22:00:00 +0800
+redirect_to: https://hmcl-snapshot-update.netlify.app
 ---
-
-正在前往 HMCL-Snapshot 下载页面，点击下载即可。
-
-没有前往？[点击此处](https://hmcl-snapshot-update.netlify.app/)
-
----
-
-You are going to the HMCL-Snapshot download page. Just click download after redirecting.
-
-No redirect? [Click here](https://hmcl-snapshot-update.netlify.app/)
-
-
-<script>
-    /* 等待 5 秒. */
-    setTimeout(function() {
-        window.location.href = "https://hmcl-snapshot-update.netlify.app/";
-    }, 5000);
-</script>


### PR DESCRIPTION
> 似乎该快照更新不再维护了，不确定该页面是否应继续存在。
