### PR TITLE
优化集合页面

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -113,6 +113,7 @@ defaults:
       hits: true
       toc: true
       toc_sticky: true
+      excerpt: ""
   - scope:
       path: ""
       type: downloads

--- a/_pages/docs.md
+++ b/_pages/docs.md
@@ -3,6 +3,5 @@ title: 文档
 layout: collection
 permalink: /docs/
 collection: docs
-entries_layout: grid
 classes: wide
 ---

--- a/_pages/downloads.md
+++ b/_pages/downloads.md
@@ -3,6 +3,5 @@ title: 下载
 layout: collection
 permalink: /downloads/
 collection: downloads
-entries_layout: grid
 classes: wide
 ---

--- a/_pages/launcher.md
+++ b/_pages/launcher.md
@@ -3,6 +3,5 @@ title: 启动器
 layout: collection
 permalink: /launcher/
 collection: launcher
-entries_layout: grid
 classes: wide
 ---

--- a/_pages/modpack.md
+++ b/_pages/modpack.md
@@ -3,6 +3,5 @@ title: 整合包
 layout: collection
 permalink: /modpack/
 collection: modpack
-entries_layout: grid
 classes: wide
 ---

--- a/_pages/multiplayer.md
+++ b/_pages/multiplayer.md
@@ -3,6 +3,5 @@ title: 多人联机
 layout: collection
 permalink: /multiplayer/
 collection: multiplayer
-entries_layout: grid
 classes: wide
 ---


### PR DESCRIPTION
# 优化集合页面

1. 设置默认摘要为空
2. 使用 list 布局替代 grid 布局

## 预览

- https://neveler.github.io/HMCL-docs/PR12/docs/
- https://neveler.github.io/HMCL-docs/PR12/downloads/
- https://neveler.github.io/HMCL-docs/PR12/launcher/
- https://neveler.github.io/HMCL-docs/PR12/modpack/
- https://neveler.github.io/HMCL-docs/PR12/multiplayer/
