### PR TITLE
避免将包含 redirect_to 的页面视为集合文档

### DIFF
--- a/redirects/hmcl-snapshot-update.yml
+++ b/redirects/hmcl-snapshot-update.yml
@@ -1,4 +1,4 @@
 ---
-title: 下载 HMCL-Snapshot 版本
+permalink: /downloads/hmcl-snapshot-update.html
 redirect_to: https://hmcl-snapshot-update.netlify.app
 ---


### PR DESCRIPTION
# 避免将包含 redirect_to 的页面视为集合文档

> [!NOTE]
> redirects/hmcl-snapshot-update.yml 尽管使用的是 yaml 文件但其仍然是一个 Jekyll::Page 对象因此  `---` 不可省略。该文件没有内容且 yaml 支持 Front Matter 的结构中的 `---` 此外使用 yaml 格式可以为 Front Matter 中的数据提供高亮，故使用 yaml 文件。

由于该页面无实际内容，且用途为页面重定向，故其不宜再作为集合文章存在于集合列表中。

## 预览

https://neveler.github.io/HMCL-docs/PR15/downloads/hmcl-snapshot-update.html
