### PR TITLE
优先使用 WebP 版本的图片

### DIFF
--- a/_plugins/auto-link.rb
+++ b/_plugins/auto-link.rb
@@ -1,8 +1,8 @@
 require "nokogiri"
 require "addressable/uri"
 
-Jekyll::Hooks.register [:pages, :documents], :post_convert do |doc|
-  next unless doc.output_ext == ".html"
+def auto_link(doc)
+  return unless doc.output_ext == ".html"
 
   site = doc.site
   liquid_context = Liquid::Context.new({}, {}, { site: site })

--- a/_plugins/auto-webp.rb
+++ b/_plugins/auto-webp.rb
@@ -1,0 +1,28 @@
+require "nokogiri"
+require "addressable/uri"
+
+def auto_webp(doc)
+  return unless doc.output_ext == ".html"
+
+  site = doc.site
+  liquid_context = Liquid::Context.new({}, {}, { site: site })
+
+  fragment = Nokogiri::HTML::DocumentFragment.parse(doc.content)
+  fragment.css("img[src^=\"/assets/\"]").each do |item|
+    next unless item["src"]
+    uri = Addressable::URI.parse(item["src"])
+    next if uri.nil?
+
+    source_path = uri.path
+    webp_path = "#{source_path}.webp"
+    begin
+      uri.path = Liquid::Template.parse("{% link #{source_path[1..]} %}").render!(liquid_context)
+      item["src"] = uri.to_s
+      uri.path = Liquid::Template.parse("{% link #{webp_path[1..]} %}").render!(liquid_context)
+      item.wrap("<picture><source srcset=\"#{uri.to_s}\" type=\"image/webp\"></picture>")
+    rescue => e
+      # Ignored
+    end
+  end
+  doc.content = fragment.to_html
+end

--- a/_plugins/hook.rb
+++ b/_plugins/hook.rb
@@ -1,0 +1,7 @@
+require_relative "auto-link"
+require_relative "auto-webp"
+
+Jekyll::Hooks.register [:pages, :documents], :post_convert do |doc|
+  auto_webp(doc)
+  auto_link(doc)
+end


### PR DESCRIPTION
# 优先使用 WebP 版本的图片

> [!NOTE]
> 本 PR 并不包含实际的 webp 文件，可以配合 #350

## 介绍

插件在构建时会扫描所有 `src` 以 `/assets/` 开头的 `<img>` 标签，并在存在 WebP 版本时将其改写为 `<picture>` 以优先使用 WebP 格式的图片。

若图片路径为 `/assets/test/a.png`，则对应的 WebP 版本路径应为 `/assets/test/a.png.webp`。

```html
<picture><source srcset="/HMCL-docs/PR16/assets/img/docs/about-questions/img.png.webp" type="image/webp"><img src="/HMCL-docs/PR16/assets/img/docs/about-questions/img.png" alt=""></picture>
```

Closes #318
