### PR TITLE
新增图片自动生成 WebP 格式的工作流

### DIFF
--- a/.github/workflows/webp.yml
+++ b/.github/workflows/webp.yml
@@ -1,0 +1,54 @@
+name: Auto Convert WebP
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - assets/img/docs/**/*.jpg
+      - assets/img/docs/**/*.png
+      - assets/img/docs/**/*.gif
+  workflow_dispatch:
+concurrency:
+  group: webp
+  cancel-in-progress: false
+jobs:
+  convert:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q webp parallel
+      - name: Convert
+        run: |
+          find ./assets/img/docs -name '*.png' | parallel -j100% cwebp -lossless {} -o {}.webp
+          find ./assets/img/docs -name '*.jpg' | parallel -j100% cwebp -q 80 {} -o {}.webp
+          find ./assets/img/docs -name '*.gif' | parallel -j100% gif2webp -lossy -q 80 {} -o {}.webp
+      - name: Check
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "continue=true" >> $GITHUB_ENV
+          else
+            echo "continue=false" >> $GITHUB_ENV
+          fi
+      - name: Commit And Create PR
+        if: ${{ env.continue == 'true' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH_NAME="bot/webp"
+          git checkout -b "$BRANCH_NAME"
+          git add .
+          git commit -m "Auto Convert WebP"
+          git push origin -f "$BRANCH_NAME"
+          OPEN_PR=$(gh pr list --base main --head "$BRANCH_NAME" --state open --json number --jq '.[].number')
+          if [ -z "$OPEN_PR" ]; then
+            gh pr create --title "Auto Convert WebP" --fill --base main --head "$BRANCH_NAME"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# 新增图片自动生成 WebP 格式的工作流

支持在 `push` `PNG` `JPG` `GIF` 文件到 `main` 分支的 `assets/img/docs/` 目录下时触发，也可手动触发。

工作流触发后，会自动为 `assets/img/docs` 下的所有 `PNG` `JPG` `GIF` 文件生成 `WebP` 格式并覆盖原文件。随后通过 Git 检查是否有变更，如有变更则以 `github-actions[bot]` 的身份将提交强制推送到 `origin:bot/webp` 并检测是否已有开启的 PR 如无则创建新的 PR。
