### PR TITLE
优化预览提示中的反馈链接

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -232,12 +232,16 @@ jobs:
           cache-version: PR-${{ env.GITHUB_PR_NUMBER }}
       - name: Jekyll Build
         run: |
-          echo "url: https://${{ needs.preview-create-init.outputs.domain }}" > _action.yml
-          echo "baseurl: ${{ needs.preview-create-init.outputs.pathname }}/PR${{ env.GITHUB_PR_NUMBER }}" >> _action.yml
-          echo "source: ${{ github.workspace }}" >> _action.yml
-          echo "destination: /home/runner/site" >> _action.yml
-          echo "preview:" >> _action.yml
-          echo "  pr-number: ${{ env.GITHUB_PR_NUMBER }}" >> _action.yml
+          cat > _action.yml << EOF
+          url: https://${{ needs.preview-create-init.outputs.domain }}
+          baseurl: ${{ needs.preview-create-init.outputs.pathname }}/PR${{ env.GITHUB_PR_NUMBER }}
+          source: ${{ github.workspace }}
+          destination: /home/runner/site
+          preview:
+            feedback:
+              name: "#${{ env.GITHUB_PR_NUMBER }}"
+              url: https://github.com/${{ github.repository }}/pull/${{ env.GITHUB_PR_NUMBER }}
+          EOF
           ${{ env.PREVIEW_WATCH }} || bundle install --jobs 4
           bundle exec jekyll build --trace --config _config.yml,_action.yml
       - id: upload-site

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,15 +4,15 @@ layout: compress
 
 <!doctype html>
 {% include copyright.html %}
-<html lang="{{ site.locale | replace: "_", "-" | default: "en" }}" class="no-js">
+<html lang="{{ site.locale | default: 'en' }}" class="no-js">
   <head>
     {% include head.html %}
     {% include head/custom.html %}
   </head>
 
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{% if site.rtl %}rtl{% else %}ltr{% endif %}">
-    {% if site.preview and site.preview.pr-number %}
-    <div class="notice--warning text-center m0" style="position: sticky; top: 0; z-index: 999; padding: 0.4em;">当前站点为预览构建而非官方文档。如需反馈问题，请前往 <a href="https://github.com/HMCL-dev/HMCL-docs/pull/{{ site.preview.pr-number }}">#{{ site.preview.pr-number }}</a> 留言。</div>
+    {% if site.preview and site.preview.enabled != false %}
+    <div class="notice--warning text-center m0" style="position: sticky; top: 0; z-index: 999; padding: 0.4em;">当前站点为预览构建而非官方文档{% if site.preview.feedback %}，您可前往 <a href="{{ site.preview.feedback.url | relative_url }}">#{{ site.preview.feedback.name }}</a> 反馈问题{% endif %}。</div>
     {% endif %}
 
     {% include_cached skip-links.html %}


### PR DESCRIPTION
# 优化预览提示中的反馈链接

## 介绍

支持通过如下方式指定反馈链接地址。

```yaml
preview:
  feedback:
    name: "#1122"
    url: https://github.com/neveler/HMCL-docs/pull/1122
```

不配置 preview 或者设置 preview.enabled 为 false 可以禁用预览提示。

```yaml
preview:
  enabled: false
```

适配了未配置 preview.feedback 时预览消息的显示。

```yaml
preview:
  enabled: true
```

优化了预览构建 PR 的工作流，现在支持将反馈地址链接到正确的仓库。
