### PR TITLE
在 SEO 的 description 中正确显示字符 `|`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -158,7 +158,7 @@ title: HMCL 文档
 # title_separator: -
 # subtitle:
 # name: ""
-description: HMCL 启动器 | 跨平台 | 整合包管理 | 自动安装 | 十二年历史 | 三亿次使用
+description: HMCL 启动器 \| 跨平台 \| 整合包管理 \| 自动安装 \| 十二年历史 \| 三亿次使用
 url: https://docs.hmcl.net
 # repository:
 # teaser:


### PR DESCRIPTION
# 在 SEO 的 description 中正确显示字符 `|`

https://github.com/mmistakes/minimal-mistakes/blob/ffa59904e2cc8da8071d4a6771758c75a8db4349/_includes/seo.html#L18

```
{%- assign seo_description = seo_description | markdownify | strip_html | newline_to_br | strip_newlines | replace: '<br />', ' ' | escape_once | strip -%}
```
