### PR TITLE
添加自定义过滤器以按版本号排序字符串

### DIFF
--- a/_layouts/changelog.html
+++ b/_layouts/changelog.html
@@ -5,7 +5,7 @@ layout: document
 {{ content }}
 
 {% assign channel = page.channel | default: 'stable' %}
-{% assign changelogs = site.changelogs | where: "channel", channel | reverse %}
+{% assign changelogs = site.changelogs | where: "channel", channel | version_sort: "slug" | reverse %}
 {% for item in changelogs %}
   {% assign version = item.slug %}
   <h1 id="{% if forloop.index == 1 %}nowchange{% else %}HMCL-{{ version }}{% endif %}" data-version="{{ version }}">HMCL {{ version }}</h1>

--- a/_plugins/filter-version-sort.rb
+++ b/_plugins/filter-version-sort.rb
@@ -1,0 +1,21 @@
+module VersionSortFilter
+  def version_sort(input, property)
+    raise ArgumentError, "Cannot sort a null object." if input.nil?
+    raise ArgumentError, "Cannot sort an object with a null property." if property.nil?
+    raise ArgumentError, "Property #{property} is not an array of strings." unless valid_string_array?(input, property)
+
+    input.sort_by { |version| version_to_numbers(version[property]) }
+  end
+
+  private
+
+  def valid_string_array?(array, property)
+    array.is_a?(Array) && array.all? { |element| element[property].is_a?(String) }
+  end
+
+  def version_to_numbers(version_string)
+    version_string.split('.').map { |n| n.to_i }
+  end
+end
+
+Liquid::Template.register_filter(VersionSortFilter)


### PR DESCRIPTION
# 添加自定义过滤器以按版本号排序字符串

定义了自定义过滤器 version_sort，该过滤器需要传入对象数组中表示版本号的属性名称。版本号必须由自然数和 . 组成，例如 5.0.6。在排序时，插件会将版本号转换为数字数组 [5, 0, 6]，然后进行排序。

https://fork-p4-docs.hmcl.workers.dev/changelog/dev

close #387
