### PR TITLE
Bump minimal-mistakes to 4.28.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 gem "jekyll", "4.4.1"
-gem "minimal-mistakes-jekyll", "4.27.3"
+gem "minimal-mistakes-jekyll", "4.28.0"
 
 group :jekyll_plugins do
   gem "jekyll-paginate", "1.1.0"

--- a/_data/settings.yaml
+++ b/_data/settings.yaml
@@ -19,6 +19,8 @@ appearance_skin_light:
     - mint
     - plum
     - sunrise
+    - catppuccin_latte
+    - catppuccin_mocha
 appearance_skin_dark:
   type: radio
   default: dark
@@ -33,3 +35,5 @@ appearance_skin_dark:
     - mint
     - plum
     - sunrise
+    - catppuccin_latte
+    - catppuccin_mocha

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,7 @@
+{% assign locale = include.locale | default: site.locale %}
 <meta charset="utf-8">
 
-{% include seo.html %}
+{% include seo.html locale=locale %}
 
 {% unless site.atom_feed.hide %}
   <link href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ site.title }} Feed">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,12 +1,13 @@
 ---
 layout: compress
 ---
+{%- assign locale = page.locale | default: layout.locale | default: site.locale %}
 
 <!doctype html>
 {% include copyright.html %}
-<html lang="{{ site.locale | replace: "_", "-" | default: "en" }}" class="no-js">
+<html lang="{{ locale | replace: "_", "-" | default: "en" }}" class="no-js">
   <head>
-    {% include head.html %}
+    {% include head.html locale=locale %}
     {% include head/custom.html %}
   </head>
 
@@ -15,8 +16,8 @@ layout: compress
     <div class="notice--warning text-center m0" style="position: sticky; top: 0; z-index: 999; padding: 0.4em;">当前站点为预览构建而非官方文档。如需反馈问题，请前往 <a href="https://github.com/HMCL-dev/HMCL-docs/pull/{{ site.preview.pr-number }}">#{{ site.preview.pr-number }}</a> 留言。</div>
     {% endif %}
 
-    {% include_cached skip-links.html %}
-    {% include_cached masthead.html %}
+    {% include_cached skip-links.html locale=locale %}
+    {% include_cached masthead.html locale=locale %}
 
     <div class="initial-content">
       {{ content }}
@@ -25,17 +26,17 @@ layout: compress
 
     {% if site.search == true %}
       <div class="search-content">
-        {% include_cached search/search_form.html %}
+        {% include_cached search/search_form.html locale=locale %}
       </div>
     {% endif %}
 
     <div id="footer" class="page__footer">
       <footer>
         {% include footer/custom.html %}
-        {% include_cached footer.html %}
+        {% include_cached footer.html locale=locale %}
       </footer>
     </div>
 
-    {% include scripts.html %}
+    {% include scripts.html locale=locale %}
   </body>
 </html>

--- a/_sass/minimal-mistakes-plus.scss
+++ b/_sass/minimal-mistakes-plus.scss
@@ -11,10 +11,6 @@ blockquote {
   word-break: break-word;
 }
 
-.notice ul:first-child {
-  margin-top: 0;
-}
-
 .task-list-item label {
   display: inline
 }

--- a/assets/css/skins/catppuccin_latte.scss
+++ b/assets/css/skins/catppuccin_latte.scss
@@ -1,0 +1,8 @@
+---
+---
+
+@charset "utf-8";
+
+$sans-serif: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+@import "minimal-mistakes/skins/catppuccin_latte";
+@import "minimal-mistakes-plus";

--- a/assets/css/skins/catppuccin_mocha.scss
+++ b/assets/css/skins/catppuccin_mocha.scss
@@ -1,0 +1,8 @@
+---
+---
+
+@charset "utf-8";
+
+$sans-serif: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+@import "minimal-mistakes/skins/catppuccin_mocha";
+@import "minimal-mistakes-plus";

--- a/settings.yaml
+++ b/settings.yaml
@@ -16,28 +16,32 @@ data:
         title: 亮色皮肤
         description: 亮色模式下应用的皮肤。
         options:
-          default: 默认
-          air: 天空
-          aqua: 水蓝
-          contrast: 高对比
-          dark: 暗色
-          dirt: 泥土
-          neon: 霓虹
-          mint: 薄荷
-          plum: 梅紫
-          sunrise: 日出
+          default: 默认 (Default)
+          air: 天空 (Air)
+          aqua: 水蓝 (Aque)
+          contrast: 高对比 (Contrast)
+          dark: 暗色 (Dark)
+          dirt: 泥土 (Dirt)
+          neon: 霓虹 (Neno)
+          mint: 薄荷 (Mint)
+          plum: 梅紫 (Plum)
+          sunrise: 日出 (Sunrise)
+          catppuccin_latte: Catppuccin Latte
+          catppuccin_mocha: Catppuccin Mocha
       appearance_skin_dark:
         title: 暗色皮肤
         description: 暗色模式下应用的皮肤。
         options:
-          default: 默认
-          air: 天空
-          aqua: 水蓝
-          contrast: 高对比
-          dark: 暗色
-          dirt: 泥土
-          neon: 霓虹
-          mint: 薄荷
-          plum: 梅紫
-          sunrise: 日出
+          default: 默认 (Default)
+          air: 天空 (Air)
+          aqua: 水蓝 (Aque)
+          contrast: 高对比 (Contrast)
+          dark: 暗色 (Dark)
+          dirt: 泥土 (Dirt)
+          neon: 霓虹 (Neno)
+          mint: 薄荷 (Mint)
+          plum: 梅紫 (Plum)
+          sunrise: 日出 (Sunrise)
+          catppuccin_latte: Catppuccin Latte
+          catppuccin_mocha: Catppuccin Mocha
 ---


### PR DESCRIPTION
# Bump minimal-mistakes to 4.28.0

## 变更

1. 更新依赖版本
2. 同步上游 `_includes/head.html` `_layouts/default.html` 的变更
3. 支持新皮肤

---

https://github.com/mmistakes/minimal-mistakes/discussions/5450

https://p2-docs.hmcl.workers.dev