### PR TITLE
构建包含 [skip cache] 的提交时禁用构建缓存

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,9 @@ steps:
   commands:
     - bundle config mirror.https://rubygems.org https://mirrors.cloud.tencent.com/rubygems
     - bundle install --verbose
-    - bundle exec jekyll build --trace --verbose --config _config.yml,_config.drone.yml
+    - |
+      CACHE_FLAG=$(echo "$DRONE_COMMIT_MESSAGE" | grep -q '\[skip cache\]' && echo "--disable-disk-cache" || echo "")
+      bundle exec jekyll build --trace --verbose --config _config.yml,_config.drone.yml $CACHE_FLAG
   volumes:
   - name: dist
     path: /drone/src/_site


### PR DESCRIPTION
本 PR 旨在解决当前构建流程在特定变更中无法跳过构建缓存的问题，只需在 commit 消息中添加 `[skip cache]` 即可。

---

https://jekyllrb.com/docs/configuration/options/
https://docs.drone.io/pipeline/environment/reference/
https://docs.drone.io/pipeline/environment/reference/drone-commit-message/
