### PR TITLE
减少集合列表页的最大列数

### DIFF
--- a/_sass/minimal-mistakes-plus.scss
+++ b/_sass/minimal-mistakes-plus.scss
@@ -1,4 +1,40 @@
-@import "minimal-mistakes";
+/* Copyright comment */
+@import "minimal-mistakes/copyright";
+
+/* Variables */
+@import "minimal-mistakes/variables";
+
+/* Mixins and functions */
+@import "minimal-mistakes/vendor/breakpoint/breakpoint";
+@include breakpoint-set("to ems", true);
+@import "minimal-mistakes/vendor/magnific-popup/magnific-popup"; // Magnific Popup
+@import "minimal-mistakes/vendor/susy/susy";
+@import "minimal-mistakes/mixins";
+
+/* Core CSS */
+@import "minimal-mistakes/reset";
+@import "minimal-mistakes/base";
+@import "minimal-mistakes/forms";
+@import "minimal-mistakes/tables";
+@import "minimal-mistakes/animations";
+
+/* Components */
+@import "minimal-mistakes/buttons";
+@import "minimal-mistakes/notices";
+@import "minimal-mistakes/masthead";
+@import "minimal-mistakes/navigation";
+@import "minimal-mistakes/footer";
+@import "minimal-mistakes/search";
+@import "minimal-mistakes/syntax";
+
+/* Utility classes */
+@import "minimal-mistakes/utilities";
+
+/* Layout specific */
+@import "minimal-mistakes/page";
+@import "minimal-mistakes-plus/archive";
+@import "minimal-mistakes/sidebar";
+@import "minimal-mistakes/print";
 
 blockquote {
   margin-inline: 0;

--- a/_sass/minimal-mistakes-plus/_archive.scss
+++ b/_sass/minimal-mistakes-plus/_archive.scss
@@ -183,12 +183,7 @@
   }
 
   .archive__item-excerpt {
-    display: none;
-
-    @include breakpoint($medium) {
-      display: block;
-      font-size: $type-size-6;
-    }
+    font-size: $type-size-6;
   }
 
   .archive__item-teaser {

--- a/_sass/minimal-mistakes-plus/_archive.scss
+++ b/_sass/minimal-mistakes-plus/_archive.scss
@@ -1,0 +1,403 @@
+/* ==========================================================================
+   ARCHIVE
+   ========================================================================== */
+
+.archive {
+  margin-top: 1em;
+  margin-bottom: 2em;
+
+  @include breakpoint($large) {
+    float: inline-end;
+    width: calc(100% - #{$right-sidebar-width-narrow});
+    padding-inline-end: $right-sidebar-width-narrow;
+  }
+
+  @include breakpoint($x-large) {
+    width: calc(100% - #{$right-sidebar-width});
+    padding-inline-end: $right-sidebar-width;
+  }
+}
+
+.archive__item {
+  position: relative;
+
+  a {
+    position: relative;
+    z-index: 10;
+  }
+
+  a[rel="permalink"] {
+    position: static;
+  }
+}
+
+.archive__subtitle {
+  margin: 1.414em 0 0.5em;
+  padding-bottom: 0.5em;
+  font-size: $type-size-5;
+  color: $muted-text-color;
+  border-bottom: 1px solid $border-color;
+
+  + .list__item .archive__item-title {
+    margin-top: 0.5em;
+  }
+}
+
+.archive__item-title {
+  margin-bottom: 0.25em;
+  font-family: $sans-serif-narrow;
+  line-height: initial;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  a[rel="permalink"]::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+  }
+
+  a + a {
+    opacity: 0.5;
+  }
+}
+
+/* remove border*/
+.page__content {
+  .archive__item-title {
+    margin-top: 1em;
+    border-bottom: none;
+  }
+}
+
+.archive__item-excerpt {
+  margin-top: 0;
+  font-size: $type-size-6;
+
+  & + p {
+    text-indent: 0;
+  }
+
+  a {
+    position: relative;
+  }
+}
+
+.archive__item-teaser {
+  position: relative;
+  border-radius: $border-radius;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+  }
+}
+
+.archive__item-caption {
+  position: absolute;
+  bottom: 0;
+  inset-inline-end: 0;
+  margin: 0 auto;
+  padding: 2px 5px;
+  color: #fff;
+  font-family: $caption-font-family;
+  font-size: $type-size-8;
+  background: #000;
+  text-align: end;
+  z-index: 5;
+  opacity: 0.5;
+  border-radius: $border-radius 0 0 0;
+
+  @include breakpoint($large) {
+    padding: 5px 10px;
+  }
+
+  a {
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+/*
+   List view
+   ========================================================================== */
+
+.list__item {
+  .page__meta {
+    margin: 0 0 4px;
+    font-size: 0.6em;
+  }
+}
+
+/*
+   Grid view
+   ========================================================================== */
+
+.archive {
+  .grid__wrapper {
+    /* extend grid elements to the right */
+
+    @include breakpoint($large) {
+      margin-inline-end: -1 * $right-sidebar-width-narrow;
+    }
+
+    @include breakpoint($x-large) {
+      margin-inline-end: -1 * $right-sidebar-width;
+    }
+  }
+}
+
+.grid__item {
+  margin-bottom: 2em;
+
+  @include breakpoint($small) {
+    float: inline-start;
+    width: span(5 of 10);
+
+    &:nth-child(2n + 1) {
+      clear: both;
+      margin-inline-start: 0;
+    }
+
+    &:nth-child(2n + 2) {
+      clear: none;
+      margin-inline-start: gutter(of 10);
+    }
+  }
+
+  .page__meta {
+    margin: 0 0 4px;
+    font-size: 0.6em;
+  }
+
+  .page__meta-sep {
+    display: block;
+
+    &::before {
+      display: none;
+    }
+  }
+
+  .archive__item-title {
+    margin-top: 0.5em;
+    font-size: $type-size-5;
+  }
+
+  .archive__item-excerpt {
+    display: none;
+
+    @include breakpoint($medium) {
+      display: block;
+      font-size: $type-size-6;
+    }
+  }
+
+  .archive__item-teaser {
+    @include breakpoint($small) {
+      max-height: 200px;
+    }
+
+    @include breakpoint($medium) {
+      max-height: 120px;
+    }
+  }
+}
+
+/*
+   Features
+   ========================================================================== */
+
+.feature__wrapper {
+  @include clearfix();
+  margin-bottom: 2em;
+  border-bottom: 1px solid $border-color;
+
+  .archive__item-title {
+    margin-bottom: 0;
+  }
+}
+
+.feature__item {
+  position: relative;
+  margin-bottom: 2em;
+  font-size: 1.125em;
+
+  @include breakpoint($small) {
+    float: inline-start;
+    margin-bottom: 0;
+    width: span(4 of 12);
+
+    &:nth-child(3n + 1) {
+      clear: both;
+      margin-inline-start: 0;
+    }
+
+    &:nth-child(3n + 2) {
+      clear: none;
+      margin-inline-start: gutter(of 12);
+    }
+
+    &:nth-child(3n + 3) {
+      clear: none;
+      margin-inline-start: gutter(of 12);
+    }
+
+    .feature__item-teaser {
+      max-height: 200px;
+      overflow: hidden;
+    }
+  }
+
+  .archive__item-body {
+    padding-inline: gutter(1 of 12);
+  }
+
+  a.btn::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+  }
+
+  &--left, &--right {
+    position: relative;
+    margin-inline: 0;
+    width: 100%;
+    clear: both;
+    font-size: 1.125em;
+
+    a.btn::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+    }
+
+    .archive__item-teaser {
+      margin-bottom: 2em;
+    }
+  }
+
+  &--left {
+    float: inline-start;
+
+    .archive__item {
+      float: inline-start;
+    }
+
+    @include breakpoint($small) {
+      .archive__item-teaser {
+        float: inline-start;
+        width: span(5 of 12);
+      }
+
+      .archive__item-body {
+        float: inline-end;
+        width: span(7 of 12);
+        padding-inline-start: gutter(0.5 of 12);
+        padding-inline-end: gutter(1 of 12);
+      }
+    }
+  }
+
+  &--right {
+    float: inline-end;
+
+    .archive__item {
+      float: inline-end;
+    }
+
+    @include breakpoint($small) {
+      text-align: end;
+
+      .archive__item-teaser {
+        float: inline-end;
+        width: span(5 of 12);
+      }
+
+      .archive__item-body {
+        float: inline-start;
+        width: span(7 of 12);
+        padding-inline-start: gutter(1 of 12);
+        padding-inline-end: gutter(0.5 of 12);
+      }
+    }
+  }
+
+  &--center {
+    position: relative;
+    float: inline-start;
+    margin-inline: 0;
+    width: 100%;
+    clear: both;
+    font-size: 1.125em;
+
+    .archive__item {
+      float: inline-start;
+      width: 100%;
+    }
+
+    .archive__item-teaser {
+      margin-bottom: 2em;
+    }
+
+    a.btn::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+    }
+
+    @include breakpoint($small) {
+      text-align: center;
+
+      .archive__item-teaser {
+        margin: 0 auto;
+        width: span(5 of 12);
+      }
+
+      .archive__item-body {
+        margin: 0 auto;
+        width: span(7 of 12);
+      }
+    }
+  }
+}
+
+/* Place inside an archive layout */
+
+.archive {
+  .feature__wrapper {
+    .archive__item-title {
+      margin-top: 0.25em;
+      font-size: 1em;
+    }
+  }
+
+  .feature__item,
+  .feature__item--left,
+  .feature__item--center,
+  .feature__item--right {
+    font-size: 1em;
+  }
+}
+
+/*
+   Wide Pages
+   ========================================================================== */
+
+.wide {
+  .archive {
+    @include breakpoint($large) {
+      padding-inline-end: 0;
+    }
+
+    @include breakpoint($x-large) {
+      padding-inline-end: 0;
+    }
+  }
+}
+
+/* Place inside a single layout */
+
+.layout--single {
+  .feature__wrapper {
+    display: inline-block;
+  }
+}


### PR DESCRIPTION
# 减少集合列表页的最大列数

## 变更

- 列表页最大列数从四列修改为两列
- 窄屏窗口不再隐藏摘要信息

> _sass/minimal-mistakes-plus/_archive.scss 修改自 https://github.com/mmistakes/minimal-mistakes/blob/master/_sass/minimal-mistakes/_archive.scss

---

| Before | After |
| - | - |
| <img width="1920" height="1070" alt="2" src="https://github.com/user-attachments/assets/b1d3b2f2-31b7-42d0-a6cf-1eda3363e74f" /> | <img width="1920" height="1284" alt="1" src="https://github.com/user-attachments/assets/60c455a5-8b66-4495-9c5b-2e1abe648760" /> |

---

https://docs.hmcl.net/launcher/

https://p1-docs.hmcl.workers.dev/launcher/
