### PR TITLE
临时禁用磁盘缓存

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@
 # data_dir: _data
 # includes_dir: _includes
 # cache_dir: .jekyll-cache
+disable_disk_cache: true
 sass:
   # sass_dir: _sass
   # minimal-mistakes


### PR DESCRIPTION
由于 f0a110fc20d08dcda12c3819a1c225004f627c48 修改了转换器逻辑，为避免历史缓存影响导致新的转换器逻辑未生效，故临时禁用磁盘缓存。