### PR TITLE
修复 hits url tag 参数被二次编码的问题

### DIFF
--- a/_layouts/document.html
+++ b/_layouts/document.html
@@ -9,6 +9,6 @@ layout: single
 <script>
   {%- if page.author %}appendMeta("{{ page.author }}", "fas fa-user-pen");{% endif -%}
   {%- for contributor in page.contributors %}appendMeta("{{ contributor }}", "fas fa-user-pen");{% endfor -%}
-  {%- if jekyll.environment == 'production' and page.hits %}hits("{{ page.url | absolute_url | jsonify }}");{% endif -%}
+  {%- if jekyll.environment == 'production' and page.hits %}hits({{ page.url | absolute_url | jsonify }});{% endif -%}
 </script>
 {% endif %}

--- a/_layouts/document.html
+++ b/_layouts/document.html
@@ -9,6 +9,6 @@ layout: single
 <script>
   {%- if page.author %}appendMeta("{{ page.author }}", "fas fa-user-pen");{% endif -%}
   {%- for contributor in page.contributors %}appendMeta("{{ contributor }}", "fas fa-user-pen");{% endfor -%}
-  {%- if jekyll.environment == 'production' and page.hits %}hits("{{ page.url | absolute_url | url_encode }}");{% endif -%}
+  {%- if jekyll.environment == 'production' and page.hits %}hits("{{ page.url | absolute_url | jsonify }}");{% endif -%}
 </script>
 {% endif %}

--- a/assets/js/meta.js
+++ b/assets/js/meta.js
@@ -25,9 +25,7 @@
   };
   window.hits = (tag) => {
     if (settings.get("miscellaneous_hits") === "disable") return;
-    const hitsUrl = new URL("https://hits.zkitefly.eu.org");
-    hitsUrl.searchParams.set("tag", tag);
-    fetch(hitsUrl, { method: "HEAD" }).then((response) => {
+    fetch("https://hits.zkitefly.eu.org/?tag=" + tag, { method: "HEAD" }).then((response) => {
       if (response.status !== 200) return;
       const { headers } = response;
       const total = headers.get("X-Total-Hits");

--- a/assets/js/meta.js
+++ b/assets/js/meta.js
@@ -25,7 +25,9 @@
   };
   window.hits = (tag) => {
     if (settings.get("miscellaneous_hits") === "disable") return;
-    fetch("https://hits.zkitefly.eu.org/?tag=" + tag, { method: "HEAD" }).then((response) => {
+    const hitsUrl = new URL("https://hits.zkitefly.eu.org");
+    hitsUrl.searchParams.set("tag", tag);
+    fetch(hitsUrl, { method: "HEAD" }).then((response) => {
       if (response.status !== 200) return;
       const { headers } = response;
       const total = headers.get("X-Total-Hits");


### PR DESCRIPTION
> `hits("{{ page.url | absolute_url | url_encode }}");`

由于 tag 参数在传入时已完成编码，使用 hitsUrl.searchParams.set 会再次对参数编码，从而改变 tag 的实际值。这导致了新的 tag 与此前不一致，故总访问量会无法包含历史数据。

本次变更不再对传入的 tag 参数进行编码，以避免二次编码，确保 tag 值与此前版本一致。

---

https://patch-2-docs.hmcl.workers.dev