### PR TITLE
启用站点缓存

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,8 +8,8 @@
 # layouts_dir: _layouts
 # data_dir: _data
 # includes_dir: _includes
-# cache_dir: .jekyll-cache
-disable_disk_cache: true
+cache_dir: .jekyll-cache/v260615
+# disable_disk_cache: false
 sass:
   # sass_dir: _sass
   # minimal-mistakes

--- a/_plugins/post_process.rb
+++ b/_plugins/post_process.rb
@@ -8,25 +8,33 @@ Jekyll::Hooks.register :site, :post_write do |site|
 
   terser = config["terser"]
   if terser.is_a?(Hash)
+    terser_cache = Jekyll::Cache.new("PostProcess.Terser")
     terser.each do |terser_output, terser_inputs|
       next unless terser_output.is_a?(String) && terser_inputs.is_a?(Array)
 
       terser_codes = []
       terser_inputs_all_exist = true
-      terser_inputs.each do |file|
-        destination = File.join(site.dest, file)
+      terser_inputs.each do |terser_input|
+        destination = File.join(site.dest, terser_input)
         if File.exist?(destination)
           terser_codes << File.read(destination, encoding: "UTF-8")
+          Jekyll.logger.debug "Post Process:", "terser input loaded (#{terser_input})"
         else
           terser_inputs_all_exist = false
+          Jekyll.logger.warn "Post Process:", "terser skipped (#{terser_input} not found)"
           break
         end
       end
 
       if terser_inputs_all_exist
+        code = terser_codes.join(";")
+        code_hash = Digest::SHA256.hexdigest(code)
+        unless terser_cache.key?(code_hash)
+          terser_cache[code_hash] = Terser.compile(code)
+        end
         destination = File.join(site.dest, terser_output.to_s)
-        File.write(destination, Terser.compile(terser_codes.join(";")))
-        Jekyll.logger.info "Post Process:", "terser #{terser_output}"
+        File.write(destination, terser_cache[code_hash])
+        Jekyll.logger.info "Post Process:", "terser success (#{terser_output})"
       end
     end
   end
@@ -46,6 +54,24 @@ Jekyll::Hooks.register :site, :post_write do |site|
       destination = File.join(site.dest, dir)
       FileUtils.rm_rf(destination) if File.directory?(destination)
       Jekyll.logger.info "Post Process:", "remove_dirs #{dir}"
+    end
+  end
+
+  jekyll_cache_dir = File.dirname(site.cache_dir)
+  if File.basename(jekyll_cache_dir) == ".jekyll-cache"
+    current_cache_name = File.basename(site.cache_dir)
+    Dir.entries(jekyll_cache_dir).select do |entry|
+      next if entry == "." || entry == ".."
+      entry_path = File.join(jekyll_cache_dir, entry)
+      if File.file?(entry_path)
+        File.delete(entry_path)
+        Jekyll.logger.info "Post Process:", "clean_cache #{entry}"
+      elsif File.directory?(entry_path)
+        if entry < current_cache_name
+          FileUtils.rm_rf(entry_path)
+          Jekyll.logger.info "Post Process:", "clean_cache #{entry}"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
由于之前扩展 Markdown 语法的需要，临时禁用了 Jekyll 缓存，本次提交旨在重新启用缓存。本次提交调整了缓存路径，使其能够在 Drone 构建容器环境中也可以清理历史缓存。

新的缓存路径添加了一个二级版本目录用于表示当前缓存版本，此变更旨在实现缓存隔离与可控失效。当引入需要清理或重建历史缓存的变更时，只需变更该版本目录名称即可，如 `.jekyll-cache/v250102` => `.jekyll-cache/v260203`。

本次提交还为 terser 添加了构建缓存。

https://patch-3-docs.hmcl.workers.dev
