### PR TITLE
添加“验证 HMCL 文件”页面

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -49,6 +49,8 @@ docs:
         url: /changelog/dev.html
   - title: 其他
     children:
+      - title: 验证 HMCL
+        url: /verify.html
       - title: 用户协议
         url: /eula/hmcl.html
       - title: 贡献指南

--- a/_pages/verify.md
+++ b/_pages/verify.md
@@ -10,7 +10,7 @@ toc: false
   <div class="hmcl-verify__actions">
     <label class="hmcl-verify__button" for="hmcl-verify-file">选择文件</label>
     <span id="hmcl-verify-selected-file" class="hmcl-verify__file">未选择文件</span>
-    <input id="hmcl-verify-file" class="hmcl-verify__input" type="file" accept=".jar,.zip,.exe,.sh,application/java-archive,application/zip">
+    <input id="hmcl-verify-file" class="hmcl-verify__input" type="file" accept=".jar,.exe,.sh">
   </div>
 
   <div id="hmcl-verify-result" class="hmcl-verify__result" role="status" aria-live="polite" hidden></div>

--- a/_pages/verify.md
+++ b/_pages/verify.md
@@ -5,7 +5,7 @@ toc: false
 ---
 
 <div class="hmcl-verify">
-  <p>选择你下载的 HMCL 文件，页面会在本机完成验证，不会上传文件。</p>
+  <p>检查 HMCL 文件是否是官方构建。</p>
 
   <div class="hmcl-verify__actions">
     <label class="hmcl-verify__button" for="hmcl-verify-file">选择文件</label>

--- a/_pages/verify.md
+++ b/_pages/verify.md
@@ -1,0 +1,58 @@
+---
+title: 验证 HMCL 文件
+permalink: /verify.html
+toc: false
+---
+
+<div class="hmcl-verify">
+  <p>选择 HMCL 的 jar 文件后，页面会在本地浏览器中读取文件，并使用 HMCL 官方公钥验证内嵌签名。文件不会被上传。</p>
+
+  <label class="hmcl-verify__picker">
+    <span>选择文件</span>
+    <input id="hmcl-verify-file" type="file" accept=".jar,.zip,application/java-archive,application/zip">
+  </label>
+
+  <div id="hmcl-verify-result" class="hmcl-verify__result" role="status" aria-live="polite">
+    尚未选择文件。
+  </div>
+</div>
+
+<style>
+  .hmcl-verify {
+    max-width: 48rem;
+  }
+
+  .hmcl-verify__picker {
+    display: inline-flex;
+    align-items: center;
+    gap: .5rem;
+    margin: 1rem 0;
+    padding: .55rem .85rem;
+    border: 1px solid var(--global-border-color);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .hmcl-verify__picker input {
+    max-width: 20rem;
+  }
+
+  .hmcl-verify__result {
+    margin-top: 1rem;
+    padding: .85rem 1rem;
+    border: 1px solid var(--global-border-color);
+    border-radius: 4px;
+    background: var(--code-background-color);
+    white-space: pre-wrap;
+  }
+
+  .hmcl-verify__result[data-state="ok"] {
+    border-color: #2e7d32;
+  }
+
+  .hmcl-verify__result[data-state="error"] {
+    border-color: #c62828;
+  }
+</style>
+
+<script src="{{ '/assets/js/hmcl-signature-verify.js' | relative_url }}"></script>

--- a/_pages/verify.md
+++ b/_pages/verify.md
@@ -13,9 +13,7 @@ toc: false
     <input id="hmcl-verify-file" class="hmcl-verify__input" type="file" accept=".jar,.zip,.exe,.sh,application/java-archive,application/zip">
   </div>
 
-  <div id="hmcl-verify-result" class="hmcl-verify__result" role="status" aria-live="polite">
-    尚未选择文件。
-  </div>
+  <div id="hmcl-verify-result" class="hmcl-verify__result" role="status" aria-live="polite" hidden></div>
 </div>
 
 <style>
@@ -82,6 +80,10 @@ toc: false
     font-size: .95rem;
     line-height: 1.6;
     white-space: pre-wrap;
+  }
+
+  .hmcl-verify__result[hidden] {
+    display: none;
   }
 
   .hmcl-verify__result[data-state="ok"] {

--- a/_pages/verify.md
+++ b/_pages/verify.md
@@ -5,12 +5,13 @@ toc: false
 ---
 
 <div class="hmcl-verify">
-  <p>选择 HMCL 的 jar 文件后，页面会在本地浏览器中读取文件，并使用 HMCL 官方公钥验证内嵌签名。文件不会被上传。</p>
+  <p>选择你下载的 HMCL 文件，页面会在本机完成验证，不会上传文件。</p>
 
-  <label class="hmcl-verify__picker">
-    <span>选择文件</span>
-    <input id="hmcl-verify-file" type="file" accept=".jar,.zip,application/java-archive,application/zip">
-  </label>
+  <div class="hmcl-verify__actions">
+    <label class="hmcl-verify__button" for="hmcl-verify-file">选择文件</label>
+    <span id="hmcl-verify-selected-file" class="hmcl-verify__file">未选择文件</span>
+    <input id="hmcl-verify-file" class="hmcl-verify__input" type="file" accept=".jar,.zip,.exe,.sh,application/java-archive,application/zip">
+  </div>
 
   <div id="hmcl-verify-result" class="hmcl-verify__result" role="status" aria-live="polite">
     尚未选择文件。
@@ -19,30 +20,67 @@ toc: false
 
 <style>
   .hmcl-verify {
-    max-width: 48rem;
+    max-width: 42rem;
+    font-size: 1rem;
+    line-height: 1.65;
   }
 
-  .hmcl-verify__picker {
+  .hmcl-verify p {
+    margin-bottom: 1rem;
+  }
+
+  .hmcl-verify__actions {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    flex-wrap: wrap;
+    margin: 1rem 0;
+  }
+
+  .hmcl-verify__button {
     display: inline-flex;
     align-items: center;
-    gap: .5rem;
-    margin: 1rem 0;
-    padding: .55rem .85rem;
-    border: 1px solid var(--global-border-color);
+    justify-content: center;
+    min-height: 2.25rem;
+    padding: .35rem .8rem;
+    border: 1px solid rgba(127, 127, 127, .45);
     border-radius: 4px;
+    background: rgba(127, 127, 127, .12);
+    color: inherit;
+    font-size: .9rem;
+    line-height: 1.2;
     cursor: pointer;
   }
 
-  .hmcl-verify__picker input {
-    max-width: 20rem;
+  .hmcl-verify__button:hover {
+    filter: brightness(.95);
+  }
+
+  .hmcl-verify__file {
+    min-width: 0;
+    max-width: 100%;
+    opacity: .72;
+    font-size: .9rem;
+    overflow-wrap: anywhere;
+  }
+
+  .hmcl-verify__input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
   }
 
   .hmcl-verify__result {
     margin-top: 1rem;
-    padding: .85rem 1rem;
-    border: 1px solid var(--global-border-color);
+    padding: .75rem .9rem;
+    border: 1px solid rgba(127, 127, 127, .35);
+    border-left-width: 4px;
     border-radius: 4px;
-    background: var(--code-background-color);
+    background: rgba(127, 127, 127, .08);
+    font-size: .95rem;
+    line-height: 1.6;
     white-space: pre-wrap;
   }
 

--- a/assets/js/hmcl-signature-verify.js
+++ b/assets/js/hmcl-signature-verify.js
@@ -5,6 +5,24 @@
   const LAUNCHER_ENTRY_NAMES = ["assets/HMCLauncher.exe", "assets/HMCLauncher.sh"];
   const PUBLIC_KEY_DER_BASE64 = "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAypkXnIxC3KzQsICAK9lEan3icR8OUREbW1vqANzi7ne0EXAyFh1Ow10HIY+SIWHVhsIkS/mvNyUyW5TIPc22djWNQKf6OukOY2/htJpolj4l/uhPGe4BoFiV8m2jvyKq0X7truazc9/BDrLKkoIVIkXb0PenVs1AlFLnXzLEu9Lj4kxfkRO4zdV4CMHYWLWLLP9Dj0/Xg+tj9n/QX/IWVVrBporKiJgg99WztKw7wQ/Zd+Syu8vfa6IjpgRojtOiCb8MUvEUHcs8RG/PPRACJ8bNwCaNc0RNLoyfVGjjZGFh95XPr6huJYmn/11j45GTB9I5w77JnF83AWwAPyx15z6yHKm4epzXJ9yFrTK5nATQGD1H2i8rdg4ZvsjFE4nxEYTWDTkk9nQdZs3n5Os+pUh8hyyjsa4Hh2yjmfcivcE/KzyP8JH15OWH9QOHwdfRTDu3v4AxSZCuQKlhaSpYbHFahE+jqP+Pr0+Bc/e5ybu6SdAELlOJrVYU6pkgrvYJmkV6Ahfm3P8OZKt72MAGxDfdYNUA70QWMMC1YP+GQYedC+oLA4/BhQ1Su9AfUUdQGN0a8a6uaZFX5QyiA/6KrRUC06dQdXi9ZOCx8LY28Snl7TjgmOef15HnnmmQTbARJuR0eenprzOXJXJzkS6/Vx1ak/9gNRA8yMiVM9lIilsCAwEAAQ==";
 
+  const VerificationErrorCode = Object.freeze({
+    MISSING_SIGNATURE: "missing-signature",
+    INVALID_SIGNATURE: "invalid-signature",
+    INVALID_LAUNCHER_HEADER: "invalid-launcher-header",
+    INVALID_ZIP: "invalid-zip",
+    UNSUPPORTED_ZIP: "unsupported-zip",
+    UNSUPPORTED_BROWSER: "unsupported-browser",
+  });
+
+  class VerificationError extends Error {
+    constructor(code, message, cause) {
+      super(message);
+      this.name = "VerificationError";
+      this.code = code;
+      this.cause = cause;
+    }
+  }
+
   const fileInput = document.getElementById("hmcl-verify-file");
   const resultElement = document.getElementById("hmcl-verify-result");
   const selectedFileElement = document.getElementById("hmcl-verify-selected-file");
@@ -47,7 +65,7 @@
     const signatureEntry = entries.find((entry) => entry.name === SIGNATURE_ENTRY_NAME);
 
     if (!signatureEntry) {
-      throw new Error(`missing ${SIGNATURE_ENTRY_NAME}`);
+      throw new VerificationError(VerificationErrorCode.MISSING_SIGNATURE, `missing ${SIGNATURE_ENTRY_NAME}`);
     }
 
     const signature = await readEntryContent(fileBuffer, signatureEntry);
@@ -90,7 +108,7 @@
     );
 
     if (!valid) {
-      throw new Error("invalid signature");
+      throw new VerificationError(VerificationErrorCode.INVALID_SIGNATURE, "invalid signature");
     }
 
     const launcherHeader = await verifyLauncherHeader(fileBuffer, entries);
@@ -108,12 +126,12 @@
     const centralDirectoryOffset = view.getUint32(end + 16, true);
 
     if (centralDirectorySize === 0xffffffff || centralDirectoryOffset === 0xffffffff) {
-      throw new Error("Zip64 is not supported");
+      throw new VerificationError(VerificationErrorCode.UNSUPPORTED_ZIP, "Zip64 is not supported");
     }
 
     const zipStartOffset = end - centralDirectorySize - centralDirectoryOffset;
     if (zipStartOffset < 0) {
-      throw new Error("invalid zip offsets");
+      throw new VerificationError(VerificationErrorCode.INVALID_ZIP, "invalid zip offsets");
     }
 
     const entries = [];
@@ -122,7 +140,7 @@
 
     for (let index = 0; index < totalEntries; index += 1) {
       if (offset + 46 > view.byteLength || view.getUint32(offset, true) !== 0x02014b50) {
-        throw new Error("invalid central directory");
+        throw new VerificationError(VerificationErrorCode.INVALID_ZIP, "invalid central directory");
       }
 
       const flags = view.getUint16(offset + 8, true);
@@ -149,7 +167,7 @@
     }
 
     if (offset !== centralDirectoryEnd) {
-      throw new Error("central directory size mismatch");
+      throw new VerificationError(VerificationErrorCode.INVALID_ZIP, "central directory size mismatch");
     }
 
     entries.zipStartOffset = zipStartOffset;
@@ -168,7 +186,7 @@
       }
     }
 
-    throw new Error("end of central directory not found");
+    throw new VerificationError(VerificationErrorCode.INVALID_ZIP, "end of central directory not found");
   }
 
   async function readEntryContent(buffer, entry) {
@@ -176,7 +194,7 @@
     const offset = entry.localHeaderOffset;
 
     if (offset + 30 > view.byteLength || view.getUint32(offset, true) !== 0x04034b50) {
-      throw new Error(`invalid local header: ${entry.name}`);
+      throw new VerificationError(VerificationErrorCode.INVALID_ZIP, `invalid local header: ${entry.name}`);
     }
 
     const fileNameLength = view.getUint16(offset + 26, true);
@@ -185,7 +203,7 @@
     const dataEnd = dataStart + entry.compressedSize;
 
     if (dataEnd > view.byteLength) {
-      throw new Error(`entry data is truncated: ${entry.name}`);
+      throw new VerificationError(VerificationErrorCode.INVALID_ZIP, `entry data is truncated: ${entry.name}`);
     }
 
     const compressedData = new Uint8Array(buffer, dataStart, entry.compressedSize);
@@ -198,7 +216,10 @@
       return inflateRaw(compressedData, entry.name, entry.uncompressedSize);
     }
 
-    throw new Error(`unsupported compression method ${entry.method}: ${entry.name}`);
+    throw new VerificationError(
+      VerificationErrorCode.UNSUPPORTED_ZIP,
+      `unsupported compression method ${entry.method}: ${entry.name}`
+    );
   }
 
   async function verifyLauncherHeader(buffer, entries) {
@@ -226,24 +247,40 @@
       }
     }
 
-    throw new Error("launcher header does not match signed assets");
+    throw new VerificationError(
+      VerificationErrorCode.INVALID_LAUNCHER_HEADER,
+      "launcher header does not match signed assets"
+    );
   }
 
   async function inflateRaw(data, entryName, expectedSize) {
     if (typeof DecompressionStream === "undefined") {
-      throw new Error("this browser does not support DecompressionStream");
+      throw new VerificationError(
+        VerificationErrorCode.UNSUPPORTED_BROWSER,
+        "this browser does not support DecompressionStream"
+      );
     }
 
     let stream;
     try {
       stream = new Blob([data]).stream().pipeThrough(new DecompressionStream("deflate-raw"));
     } catch (error) {
-      throw new Error(`this browser cannot decompress deflated zip entries: ${entryName}`);
+      throw new VerificationError(
+        VerificationErrorCode.UNSUPPORTED_BROWSER,
+        `this browser cannot decompress deflated zip entries: ${entryName}`,
+        error
+      );
     }
 
-    const output = new Uint8Array(await new Response(stream).arrayBuffer());
+    let output;
+    try {
+      output = new Uint8Array(await new Response(stream).arrayBuffer());
+    } catch (error) {
+      throw new VerificationError(VerificationErrorCode.INVALID_ZIP, `cannot decompress zip entry: ${entryName}`, error);
+    }
+
     if (output.byteLength !== expectedSize) {
-      throw new Error(`uncompressed size mismatch: ${entryName}`);
+      throw new VerificationError(VerificationErrorCode.INVALID_ZIP, `uncompressed size mismatch: ${entryName}`);
     }
     return output;
   }
@@ -327,34 +364,26 @@
   }
 
   function formatVerificationError(error) {
-    const message = error && error.message ? error.message : "";
+    switch (error && error.code) {
+      case VerificationErrorCode.MISSING_SIGNATURE:
+        return "这个文件没有 HMCL 官方签名。";
 
-    if (message.startsWith(`missing ${SIGNATURE_ENTRY_NAME}`)) {
-      return "这个文件没有 HMCL 官方签名。";
+      case VerificationErrorCode.INVALID_SIGNATURE:
+      case VerificationErrorCode.INVALID_LAUNCHER_HEADER:
+        return "该 HMCL 文件可能被篡改或已损坏，请不要使用此文件。你可以从 HMCL 官方网站重新下载 HMCL。";
+
+      case VerificationErrorCode.INVALID_ZIP:
+        return "这个文件不是有效的 HMCL 文件，或文件已经损坏。";
+
+      case VerificationErrorCode.UNSUPPORTED_ZIP:
+        return "暂不支持验证这种文件格式。";
+
+      case VerificationErrorCode.UNSUPPORTED_BROWSER:
+        return "当前浏览器不支持读取这个文件，请换用新版 Chrome、Edge 或 Firefox。";
+
+      default:
+        return "无法完成验证，请确认你选择的是从官方渠道下载的 HMCL 文件。";
     }
-
-    if (message === "invalid signature" || message === "launcher header does not match signed assets") {
-      return "该 HMCL 文件可能被篡改或已损坏，请不要使用此文件。你可以从 HMCL 官方网站重新下载 HMCL。";
-    }
-
-    if (
-      message === "end of central directory not found" ||
-      message === "invalid central directory" ||
-      message === "central directory size mismatch" ||
-      message === "invalid zip offsets" ||
-      message === "Zip64 is not supported" ||
-      message.startsWith("unsupported compression method") ||
-      message.startsWith("invalid local header") ||
-      message.startsWith("entry data is truncated")
-    ) {
-      return "这个文件不是有效的 HMCL 文件，或文件已经损坏。";
-    }
-
-    if (message.includes("DecompressionStream") || message.includes("cannot decompress")) {
-      return "当前浏览器不支持读取这个文件，请换用新版 Chrome、Edge 或 Firefox。";
-    }
-
-    return "无法完成验证，请确认你选择的是从官方渠道下载的 HMCL 文件。";
   }
 
   function setResult(message, state) {

--- a/assets/js/hmcl-signature-verify.js
+++ b/assets/js/hmcl-signature-verify.js
@@ -29,7 +29,7 @@
       setResult(
         [
           "验证通过。",
-          "该文件由 HMCL 官方签名，内容完整。",
+          "该文件是 HMCL 的官方构建。",
           `文件：${file.name}`,
           `大小：${formatBytes(file.size)}`,
           `类型：${verification.fileTypeMessage}`,

--- a/assets/js/hmcl-signature-verify.js
+++ b/assets/js/hmcl-signature-verify.js
@@ -39,7 +39,7 @@
     const file = fileInput.files && fileInput.files[0];
     if (!file) {
       setSelectedFileName("");
-      setResult("尚未选择文件。");
+      hideResult();
       return;
     }
 
@@ -412,11 +412,18 @@
 
   function setResult(message, state) {
     resultElement.textContent = message;
+    resultElement.hidden = false;
     if (state) {
       resultElement.dataset.state = state;
     } else {
       delete resultElement.dataset.state;
     }
+  }
+
+  function hideResult() {
+    resultElement.textContent = "";
+    resultElement.hidden = true;
+    delete resultElement.dataset.state;
   }
 
   function setSelectedFileName(fileName) {

--- a/assets/js/hmcl-signature-verify.js
+++ b/assets/js/hmcl-signature-verify.js
@@ -333,12 +333,8 @@
       return "这个文件没有 HMCL 官方签名。";
     }
 
-    if (message === "invalid signature") {
-      return "签名无效，文件可能已损坏或被修改。";
-    }
-
-    if (message === "launcher header does not match signed assets") {
-      return "文件开头的启动器程序不匹配，文件可能已被修改。";
+    if (message === "invalid signature" || message === "launcher header does not match signed assets") {
+      return "该 HMCL 文件可能被篡改或已损坏，请不要使用此文件。你可以从 HMCL 官方网站重新下载 HMCL。";
     }
 
     if (
@@ -346,14 +342,12 @@
       message === "invalid central directory" ||
       message === "central directory size mismatch" ||
       message === "invalid zip offsets" ||
+      message === "Zip64 is not supported" ||
+      message.startsWith("unsupported compression method") ||
       message.startsWith("invalid local header") ||
       message.startsWith("entry data is truncated")
     ) {
       return "这个文件不是有效的 HMCL 文件，或文件已经损坏。";
-    }
-
-    if (message === "Zip64 is not supported" || message.startsWith("unsupported compression method")) {
-      return "暂不支持验证这种文件格式。";
     }
 
     if (message.includes("DecompressionStream") || message.includes("cannot decompress")) {

--- a/assets/js/hmcl-signature-verify.js
+++ b/assets/js/hmcl-signature-verify.js
@@ -47,15 +47,9 @@
     setResult("正在验证，请稍候...");
 
     try {
-      const verification = await verifyHmclFile(file);
+      await verifyHmclFile(file);
       setResult(
-        [
-          "验证通过。",
-          "该文件是 HMCL 的官方构建。",
-          `文件：${file.name}`,
-          `大小：${formatBytes(file.size)}`,
-          `类型：${verification.fileTypeMessage}`,
-        ].join("\n"),
+        "验证通过，该文件是 HMCL 的官方构建，可以放心使用。",
         "ok"
       );
     } catch (error) {
@@ -126,11 +120,7 @@
       throw new VerificationError(VerificationErrorCode.INVALID_SIGNATURE, "invalid signature");
     }
 
-    const fileTypeMessage = await detectFileType(fileBuffer, archive);
-
-    return {
-      fileTypeMessage,
-    };
+    await verifyLauncherPrefix(fileBuffer, archive);
   }
 
   function readZipArchive(buffer) {
@@ -239,11 +229,11 @@
     );
   }
 
-  async function detectFileType(buffer, archive) {
+  async function verifyLauncherPrefix(buffer, archive) {
     const prefixLength = archive.zipStartOffset;
 
     if (prefixLength === 0) {
-      return "jar 文件";
+      return;
     }
 
     const prefix = new Uint8Array(buffer, 0, prefixLength);
@@ -256,7 +246,7 @@
 
       const launcherContent = await readEntryContent(buffer, launcherEntry);
       if (bytesEqual(prefix, launcherContent)) {
-        return fileTypeName(entryName);
+        return;
       }
     }
 
@@ -352,35 +342,6 @@
     }
 
     return bytes;
-  }
-
-  function formatBytes(bytes) {
-    if (bytes < 1024) {
-      return `${bytes} B`;
-    }
-
-    const units = ["KB", "MB", "GB"];
-    let value = bytes / 1024;
-    let unitIndex = 0;
-
-    while (value >= 1024 && unitIndex < units.length - 1) {
-      value /= 1024;
-      unitIndex += 1;
-    }
-
-    return `${value.toFixed(2)} ${units[unitIndex]}`;
-  }
-
-  function fileTypeName(entryName) {
-    if (entryName.endsWith(".exe")) {
-      return "Windows 可执行文件";
-    }
-
-    if (entryName.endsWith(".sh")) {
-      return "启动脚本文件";
-    }
-
-    return "已验证";
   }
 
   function formatVerificationError(error) {

--- a/assets/js/hmcl-signature-verify.js
+++ b/assets/js/hmcl-signature-verify.js
@@ -5,6 +5,7 @@
   const PUBLIC_KEY_ENTRY_NAME = "assets/hmcl_signature_publickey.der";
   const LAUNCHER_ENTRY_NAMES = ["assets/HMCLauncher.exe", "assets/HMCLauncher.sh"];
   const PUBLIC_KEY_DER_BASE64 = "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAypkXnIxC3KzQsICAK9lEan3icR8OUREbW1vqANzi7ne0EXAyFh1Ow10HIY+SIWHVhsIkS/mvNyUyW5TIPc22djWNQKf6OukOY2/htJpolj4l/uhPGe4BoFiV8m2jvyKq0X7truazc9/BDrLKkoIVIkXb0PenVs1AlFLnXzLEu9Lj4kxfkRO4zdV4CMHYWLWLLP9Dj0/Xg+tj9n/QX/IWVVrBporKiJgg99WztKw7wQ/Zd+Syu8vfa6IjpgRojtOiCb8MUvEUHcs8RG/PPRACJ8bNwCaNc0RNLoyfVGjjZGFh95XPr6huJYmn/11j45GTB9I5w77JnF83AWwAPyx15z6yHKm4epzXJ9yFrTK5nATQGD1H2i8rdg4ZvsjFE4nxEYTWDTkk9nQdZs3n5Os+pUh8hyyjsa4Hh2yjmfcivcE/KzyP8JH15OWH9QOHwdfRTDu3v4AxSZCuQKlhaSpYbHFahE+jqP+Pr0+Bc/e5ybu6SdAELlOJrVYU6pkgrvYJmkV6Ahfm3P8OZKt72MAGxDfdYNUA70QWMMC1YP+GQYedC+oLA4/BhQ1Su9AfUUdQGN0a8a6uaZFX5QyiA/6KrRUC06dQdXi9ZOCx8LY28Snl7TjgmOef15HnnmmQTbARJuR0eenprzOXJXJzkS6/Vx1ak/9gNRA8yMiVM9lIilsCAwEAAQ==";
+  const PUBLIC_KEY_DER = base64ToUint8Array(PUBLIC_KEY_DER_BASE64);
 
   const VerificationErrorCode = Object.freeze({
     MISSING_PUBLIC_KEY: "missing-public-key",
@@ -64,7 +65,8 @@
 
   async function verifyHmclFile(file) {
     const fileBuffer = await file.arrayBuffer();
-    const entries = readZipEntries(fileBuffer);
+    const archive = readZipArchive(fileBuffer);
+    const entries = archive.entries;
     const publicKeyEntry = entries.find((entry) => entry.name === PUBLIC_KEY_ENTRY_NAME);
     const signatureEntry = entries.find((entry) => entry.name === SIGNATURE_ENTRY_NAME);
 
@@ -76,9 +78,8 @@
       throw new VerificationError(VerificationErrorCode.MISSING_SIGNATURE, `missing ${SIGNATURE_ENTRY_NAME}`);
     }
 
-    const publicKeyDer = new Uint8Array(base64ToArrayBuffer(PUBLIC_KEY_DER_BASE64));
     const bundledPublicKey = await readEntryContent(fileBuffer, publicKeyEntry);
-    if (!bytesEqual(bundledPublicKey, publicKeyDer)) {
+    if (!bytesEqual(bundledPublicKey, PUBLIC_KEY_DER)) {
       throw new VerificationError(VerificationErrorCode.INVALID_PUBLIC_KEY, "public key mismatch");
     }
 
@@ -105,7 +106,7 @@
 
     const publicKey = await crypto.subtle.importKey(
       "spki",
-      publicKeyDer,
+      PUBLIC_KEY_DER,
       {
         name: "RSASSA-PKCS1-v1_5",
         hash: "SHA-512",
@@ -125,14 +126,14 @@
       throw new VerificationError(VerificationErrorCode.INVALID_SIGNATURE, "invalid signature");
     }
 
-    const launcherHeader = await verifyLauncherHeader(fileBuffer, entries);
+    const fileTypeMessage = await detectFileType(fileBuffer, archive);
 
     return {
-      fileTypeMessage: launcherHeader.message,
+      fileTypeMessage,
     };
   }
 
-  function readZipEntries(buffer) {
+  function readZipArchive(buffer) {
     const view = new DataView(buffer);
     const end = findEndOfCentralDirectory(view);
     const totalEntries = view.getUint16(end + 10, true);
@@ -184,8 +185,10 @@
       throw new VerificationError(VerificationErrorCode.INVALID_ZIP, "central directory size mismatch");
     }
 
-    entries.zipStartOffset = zipStartOffset;
-    return entries;
+    return {
+      entries,
+      zipStartOffset,
+    };
   }
 
   function findEndOfCentralDirectory(view) {
@@ -236,28 +239,24 @@
     );
   }
 
-  async function verifyLauncherHeader(buffer, entries) {
-    const prefixLength = entries.zipStartOffset || 0;
+  async function detectFileType(buffer, archive) {
+    const prefixLength = archive.zipStartOffset;
 
     if (prefixLength === 0) {
-      return {
-        message: "jar 文件",
-      };
+      return "jar 文件";
     }
 
     const prefix = new Uint8Array(buffer, 0, prefixLength);
 
     for (const entryName of LAUNCHER_ENTRY_NAMES) {
-      const launcherEntry = entries.find((entry) => entry.name === entryName);
+      const launcherEntry = archive.entries.find((entry) => entry.name === entryName);
       if (!launcherEntry) {
         continue;
       }
 
       const launcherContent = await readEntryContent(buffer, launcherEntry);
       if (bytesEqual(prefix, launcherContent)) {
-        return {
-          message: fileTypeName(entryName),
-        };
+        return fileTypeName(entryName);
       }
     }
 
@@ -290,11 +289,18 @@
     try {
       output = new Uint8Array(await new Response(stream).arrayBuffer());
     } catch (error) {
-      throw new VerificationError(VerificationErrorCode.INVALID_ZIP, `cannot decompress zip entry: ${entryName}`, error);
+      throw new VerificationError(
+        VerificationErrorCode.INVALID_ZIP,
+        `cannot decompress entry: ${entryName}`,
+        error
+      );
     }
 
     if (output.byteLength !== expectedSize) {
-      throw new VerificationError(VerificationErrorCode.INVALID_ZIP, `uncompressed size mismatch: ${entryName}`);
+      throw new VerificationError(
+        VerificationErrorCode.INVALID_ZIP,
+        `uncompressed size mismatch: ${entryName}`
+      );
     }
     return output;
   }
@@ -337,7 +343,7 @@
     return true;
   }
 
-  function base64ToArrayBuffer(base64) {
+  function base64ToUint8Array(base64) {
     const binary = atob(base64);
     const bytes = new Uint8Array(binary.length);
 
@@ -345,7 +351,7 @@
       bytes[index] = binary.charCodeAt(index);
     }
 
-    return bytes.buffer;
+    return bytes;
   }
 
   function formatBytes(bytes) {

--- a/assets/js/hmcl-signature-verify.js
+++ b/assets/js/hmcl-signature-verify.js
@@ -1,0 +1,323 @@
+(function () {
+  "use strict";
+
+  const SIGNATURE_ENTRY_NAME = "META-INF/hmcl_signature";
+  const LAUNCHER_ENTRY_NAMES = ["assets/HMCLauncher.exe", "assets/HMCLauncher.sh"];
+  const PUBLIC_KEY_DER_BASE64 = "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAypkXnIxC3KzQsICAK9lEan3icR8OUREbW1vqANzi7ne0EXAyFh1Ow10HIY+SIWHVhsIkS/mvNyUyW5TIPc22djWNQKf6OukOY2/htJpolj4l/uhPGe4BoFiV8m2jvyKq0X7truazc9/BDrLKkoIVIkXb0PenVs1AlFLnXzLEu9Lj4kxfkRO4zdV4CMHYWLWLLP9Dj0/Xg+tj9n/QX/IWVVrBporKiJgg99WztKw7wQ/Zd+Syu8vfa6IjpgRojtOiCb8MUvEUHcs8RG/PPRACJ8bNwCaNc0RNLoyfVGjjZGFh95XPr6huJYmn/11j45GTB9I5w77JnF83AWwAPyx15z6yHKm4epzXJ9yFrTK5nATQGD1H2i8rdg4ZvsjFE4nxEYTWDTkk9nQdZs3n5Os+pUh8hyyjsa4Hh2yjmfcivcE/KzyP8JH15OWH9QOHwdfRTDu3v4AxSZCuQKlhaSpYbHFahE+jqP+Pr0+Bc/e5ybu6SdAELlOJrVYU6pkgrvYJmkV6Ahfm3P8OZKt72MAGxDfdYNUA70QWMMC1YP+GQYedC+oLA4/BhQ1Su9AfUUdQGN0a8a6uaZFX5QyiA/6KrRUC06dQdXi9ZOCx8LY28Snl7TjgmOef15HnnmmQTbARJuR0eenprzOXJXJzkS6/Vx1ak/9gNRA8yMiVM9lIilsCAwEAAQ==";
+
+  const fileInput = document.getElementById("hmcl-verify-file");
+  const resultElement = document.getElementById("hmcl-verify-result");
+
+  if (!fileInput || !resultElement) {
+    return;
+  }
+
+  fileInput.addEventListener("change", async () => {
+    const file = fileInput.files && fileInput.files[0];
+    if (!file) {
+      setResult("尚未选择文件。");
+      return;
+    }
+
+    setResult("正在读取文件...");
+
+    try {
+      const verification = await verifyHmclFile(file);
+      setResult(
+        [
+          "签名有效。",
+          `文件名：${file.name}`,
+          `文件大小：${formatBytes(file.size)}`,
+          `启动器头部：${verification.launcherHeaderMessage}`,
+          `参与校验的 zip entry 数量：${verification.checkedEntries}`,
+        ].join("\n"),
+        "ok"
+      );
+    } catch (error) {
+      setResult(`验证失败：${error.message}`, "error");
+    }
+  });
+
+  async function verifyHmclFile(file) {
+    const fileBuffer = await file.arrayBuffer();
+    const entries = readZipEntries(fileBuffer);
+    const signatureEntry = entries.find((entry) => entry.name === SIGNATURE_ENTRY_NAME);
+
+    if (!signatureEntry) {
+      throw new Error(`missing ${SIGNATURE_ENTRY_NAME}`);
+    }
+
+    const signature = await readEntryContent(fileBuffer, signatureEntry);
+    const signedEntries = entries
+      .filter((entry) => entry.name !== SIGNATURE_ENTRY_NAME)
+      .sort((left, right) => {
+        if (left.name < right.name) {
+          return -1;
+        }
+        if (left.name > right.name) {
+          return 1;
+        }
+        return 0;
+      });
+
+    const signedDataChunks = [];
+    for (const entry of signedEntries) {
+      const nameBytes = new TextEncoder().encode(entry.name);
+      const content = await readEntryContent(fileBuffer, entry);
+      signedDataChunks.push(await sha512(nameBytes));
+      signedDataChunks.push(await sha512(content));
+    }
+
+    const publicKey = await crypto.subtle.importKey(
+      "spki",
+      base64ToArrayBuffer(PUBLIC_KEY_DER_BASE64),
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        hash: "SHA-512",
+      },
+      false,
+      ["verify"]
+    );
+
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      publicKey,
+      signature,
+      concatUint8Arrays(signedDataChunks)
+    );
+
+    if (!valid) {
+      throw new Error("invalid signature");
+    }
+
+    const launcherHeader = await verifyLauncherHeader(fileBuffer, entries);
+
+    return {
+      checkedEntries: signedEntries.length,
+      launcherHeaderMessage: launcherHeader.message,
+    };
+  }
+
+  function readZipEntries(buffer) {
+    const view = new DataView(buffer);
+    const end = findEndOfCentralDirectory(view);
+    const totalEntries = view.getUint16(end + 10, true);
+    const centralDirectorySize = view.getUint32(end + 12, true);
+    const centralDirectoryOffset = view.getUint32(end + 16, true);
+
+    if (centralDirectorySize === 0xffffffff || centralDirectoryOffset === 0xffffffff) {
+      throw new Error("Zip64 is not supported");
+    }
+
+    const zipStartOffset = end - centralDirectorySize - centralDirectoryOffset;
+    if (zipStartOffset < 0) {
+      throw new Error("invalid zip offsets");
+    }
+
+    const entries = [];
+    let offset = zipStartOffset + centralDirectoryOffset;
+    const centralDirectoryEnd = offset + centralDirectorySize;
+
+    for (let index = 0; index < totalEntries; index += 1) {
+      if (offset + 46 > view.byteLength || view.getUint32(offset, true) !== 0x02014b50) {
+        throw new Error("invalid central directory");
+      }
+
+      const flags = view.getUint16(offset + 8, true);
+      const method = view.getUint16(offset + 10, true);
+      const compressedSize = view.getUint32(offset + 20, true);
+      const uncompressedSize = view.getUint32(offset + 24, true);
+      const fileNameLength = view.getUint16(offset + 28, true);
+      const extraLength = view.getUint16(offset + 30, true);
+      const commentLength = view.getUint16(offset + 32, true);
+      const localHeaderOffset = view.getUint32(offset + 42, true);
+      const fileNameStart = offset + 46;
+      const fileNameEnd = fileNameStart + fileNameLength;
+      const name = decodeEntryName(new Uint8Array(view.buffer, fileNameStart, fileNameLength), flags);
+
+      entries.push({
+        name,
+        method,
+        compressedSize,
+        uncompressedSize,
+        localHeaderOffset: zipStartOffset + localHeaderOffset,
+      });
+
+      offset = fileNameEnd + extraLength + commentLength;
+    }
+
+    if (offset !== centralDirectoryEnd) {
+      throw new Error("central directory size mismatch");
+    }
+
+    entries.zipStartOffset = zipStartOffset;
+    return entries;
+  }
+
+  function findEndOfCentralDirectory(view) {
+    const minOffset = Math.max(0, view.byteLength - 22 - 0xffff);
+
+    for (let offset = view.byteLength - 22; offset >= minOffset; offset -= 1) {
+      if (view.getUint32(offset, true) === 0x06054b50) {
+        const commentLength = view.getUint16(offset + 20, true);
+        if (offset + 22 + commentLength === view.byteLength) {
+          return offset;
+        }
+      }
+    }
+
+    throw new Error("end of central directory not found");
+  }
+
+  async function readEntryContent(buffer, entry) {
+    const view = new DataView(buffer);
+    const offset = entry.localHeaderOffset;
+
+    if (offset + 30 > view.byteLength || view.getUint32(offset, true) !== 0x04034b50) {
+      throw new Error(`invalid local header: ${entry.name}`);
+    }
+
+    const fileNameLength = view.getUint16(offset + 26, true);
+    const extraLength = view.getUint16(offset + 28, true);
+    const dataStart = offset + 30 + fileNameLength + extraLength;
+    const dataEnd = dataStart + entry.compressedSize;
+
+    if (dataEnd > view.byteLength) {
+      throw new Error(`entry data is truncated: ${entry.name}`);
+    }
+
+    const compressedData = new Uint8Array(buffer, dataStart, entry.compressedSize);
+
+    if (entry.method === 0) {
+      return compressedData;
+    }
+
+    if (entry.method === 8) {
+      return inflateRaw(compressedData, entry.name, entry.uncompressedSize);
+    }
+
+    throw new Error(`unsupported compression method ${entry.method}: ${entry.name}`);
+  }
+
+  async function verifyLauncherHeader(buffer, entries) {
+    const prefixLength = entries.zipStartOffset || 0;
+
+    if (prefixLength === 0) {
+      return {
+        message: "无，普通 jar 文件",
+      };
+    }
+
+    const prefix = new Uint8Array(buffer, 0, prefixLength);
+
+    for (const entryName of LAUNCHER_ENTRY_NAMES) {
+      const launcherEntry = entries.find((entry) => entry.name === entryName);
+      if (!launcherEntry) {
+        continue;
+      }
+
+      const launcherContent = await readEntryContent(buffer, launcherEntry);
+      if (bytesEqual(prefix, launcherContent)) {
+        return {
+          message: `${entryName}，${formatBytes(prefixLength)}，内容一致`,
+        };
+      }
+    }
+
+    throw new Error("launcher header does not match signed assets");
+  }
+
+  async function inflateRaw(data, entryName, expectedSize) {
+    if (typeof DecompressionStream === "undefined") {
+      throw new Error("this browser does not support DecompressionStream");
+    }
+
+    let stream;
+    try {
+      stream = new Blob([data]).stream().pipeThrough(new DecompressionStream("deflate-raw"));
+    } catch (error) {
+      throw new Error(`this browser cannot decompress deflated zip entries: ${entryName}`);
+    }
+
+    const output = new Uint8Array(await new Response(stream).arrayBuffer());
+    if (output.byteLength !== expectedSize) {
+      throw new Error(`uncompressed size mismatch: ${entryName}`);
+    }
+    return output;
+  }
+
+  function decodeEntryName(bytes, flags) {
+    if ((flags & 0x0800) === 0) {
+      return new TextDecoder("utf-8").decode(bytes);
+    }
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  }
+
+  async function sha512(data) {
+    return new Uint8Array(await crypto.subtle.digest("SHA-512", data));
+  }
+
+  function concatUint8Arrays(chunks) {
+    const totalLength = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+
+    for (const chunk of chunks) {
+      result.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+
+    return result;
+  }
+
+  function bytesEqual(left, right) {
+    if (left.byteLength !== right.byteLength) {
+      return false;
+    }
+
+    for (let index = 0; index < left.byteLength; index += 1) {
+      if (left[index] !== right[index]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  function base64ToArrayBuffer(base64) {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+
+    return bytes.buffer;
+  }
+
+  function formatBytes(bytes) {
+    if (bytes < 1024) {
+      return `${bytes} B`;
+    }
+
+    const units = ["KB", "MB", "GB"];
+    let value = bytes / 1024;
+    let unitIndex = 0;
+
+    while (value >= 1024 && unitIndex < units.length - 1) {
+      value /= 1024;
+      unitIndex += 1;
+    }
+
+    return `${value.toFixed(2)} ${units[unitIndex]}`;
+  }
+
+  function setResult(message, state) {
+    resultElement.textContent = message;
+    if (state) {
+      resultElement.dataset.state = state;
+    } else {
+      delete resultElement.dataset.state;
+    }
+  }
+})();

--- a/assets/js/hmcl-signature-verify.js
+++ b/assets/js/hmcl-signature-verify.js
@@ -30,12 +30,14 @@
   const fileInput = document.getElementById("hmcl-verify-file");
   const resultElement = document.getElementById("hmcl-verify-result");
   const selectedFileElement = document.getElementById("hmcl-verify-selected-file");
+  let verificationRequestId = 0;
 
   if (!fileInput || !resultElement) {
     return;
   }
 
   fileInput.addEventListener("change", async () => {
+    const requestId = ++verificationRequestId;
     const file = fileInput.files && fileInput.files[0];
     if (!file) {
       setSelectedFileName("");
@@ -48,14 +50,24 @@
 
     try {
       await verifyHmclFile(file);
+      if (!isCurrentVerification(requestId)) {
+        return;
+      }
       setResult(
         "验证通过，该文件是 HMCL 的官方构建，可以放心使用。",
         "ok"
       );
     } catch (error) {
+      if (!isCurrentVerification(requestId)) {
+        return;
+      }
       setResult(`验证失败。\n${formatVerificationError(error)}`, "error");
     }
   });
+
+  function isCurrentVerification(requestId) {
+    return requestId === verificationRequestId;
+  }
 
   async function verifyHmclFile(file) {
     const fileBuffer = await file.arrayBuffer();

--- a/assets/js/hmcl-signature-verify.js
+++ b/assets/js/hmcl-signature-verify.js
@@ -7,6 +7,7 @@
 
   const fileInput = document.getElementById("hmcl-verify-file");
   const resultElement = document.getElementById("hmcl-verify-result");
+  const selectedFileElement = document.getElementById("hmcl-verify-selected-file");
 
   if (!fileInput || !resultElement) {
     return;
@@ -15,26 +16,28 @@
   fileInput.addEventListener("change", async () => {
     const file = fileInput.files && fileInput.files[0];
     if (!file) {
+      setSelectedFileName("");
       setResult("尚未选择文件。");
       return;
     }
 
-    setResult("正在读取文件...");
+    setSelectedFileName(file.name);
+    setResult("正在验证，请稍候...");
 
     try {
       const verification = await verifyHmclFile(file);
       setResult(
         [
-          "签名有效。",
-          `文件名：${file.name}`,
-          `文件大小：${formatBytes(file.size)}`,
-          `启动器头部：${verification.launcherHeaderMessage}`,
-          `参与校验的 zip entry 数量：${verification.checkedEntries}`,
+          "验证通过。",
+          "该文件由 HMCL 官方签名，内容完整。",
+          `文件：${file.name}`,
+          `大小：${formatBytes(file.size)}`,
+          `类型：${verification.fileTypeMessage}`,
         ].join("\n"),
         "ok"
       );
     } catch (error) {
-      setResult(`验证失败：${error.message}`, "error");
+      setResult(`验证失败。\n${formatVerificationError(error)}`, "error");
     }
   });
 
@@ -93,8 +96,7 @@
     const launcherHeader = await verifyLauncherHeader(fileBuffer, entries);
 
     return {
-      checkedEntries: signedEntries.length,
-      launcherHeaderMessage: launcherHeader.message,
+      fileTypeMessage: launcherHeader.message,
     };
   }
 
@@ -204,7 +206,7 @@
 
     if (prefixLength === 0) {
       return {
-        message: "无，普通 jar 文件",
+        message: "jar 文件",
       };
     }
 
@@ -219,7 +221,7 @@
       const launcherContent = await readEntryContent(buffer, launcherEntry);
       if (bytesEqual(prefix, launcherContent)) {
         return {
-          message: `${entryName}，${formatBytes(prefixLength)}，内容一致`,
+          message: fileTypeName(entryName),
         };
       }
     }
@@ -312,12 +314,67 @@
     return `${value.toFixed(2)} ${units[unitIndex]}`;
   }
 
+  function fileTypeName(entryName) {
+    if (entryName.endsWith(".exe")) {
+      return "Windows 可执行文件";
+    }
+
+    if (entryName.endsWith(".sh")) {
+      return "启动脚本文件";
+    }
+
+    return "已验证";
+  }
+
+  function formatVerificationError(error) {
+    const message = error && error.message ? error.message : "";
+
+    if (message.startsWith(`missing ${SIGNATURE_ENTRY_NAME}`)) {
+      return "这个文件没有 HMCL 官方签名。";
+    }
+
+    if (message === "invalid signature") {
+      return "签名无效，文件可能已损坏或被修改。";
+    }
+
+    if (message === "launcher header does not match signed assets") {
+      return "文件开头的启动器程序不匹配，文件可能已被修改。";
+    }
+
+    if (
+      message === "end of central directory not found" ||
+      message === "invalid central directory" ||
+      message === "central directory size mismatch" ||
+      message === "invalid zip offsets" ||
+      message.startsWith("invalid local header") ||
+      message.startsWith("entry data is truncated")
+    ) {
+      return "这个文件不是有效的 HMCL 文件，或文件已经损坏。";
+    }
+
+    if (message === "Zip64 is not supported" || message.startsWith("unsupported compression method")) {
+      return "暂不支持验证这种文件格式。";
+    }
+
+    if (message.includes("DecompressionStream") || message.includes("cannot decompress")) {
+      return "当前浏览器不支持读取这个文件，请换用新版 Chrome、Edge 或 Firefox。";
+    }
+
+    return "无法完成验证，请确认你选择的是从官方渠道下载的 HMCL 文件。";
+  }
+
   function setResult(message, state) {
     resultElement.textContent = message;
     if (state) {
       resultElement.dataset.state = state;
     } else {
       delete resultElement.dataset.state;
+    }
+  }
+
+  function setSelectedFileName(fileName) {
+    if (selectedFileElement) {
+      selectedFileElement.textContent = fileName || "未选择文件";
     }
   }
 })();

--- a/assets/js/hmcl-signature-verify.js
+++ b/assets/js/hmcl-signature-verify.js
@@ -2,11 +2,14 @@
   "use strict";
 
   const SIGNATURE_ENTRY_NAME = "META-INF/hmcl_signature";
+  const PUBLIC_KEY_ENTRY_NAME = "assets/hmcl_signature_publickey.der";
   const LAUNCHER_ENTRY_NAMES = ["assets/HMCLauncher.exe", "assets/HMCLauncher.sh"];
   const PUBLIC_KEY_DER_BASE64 = "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAypkXnIxC3KzQsICAK9lEan3icR8OUREbW1vqANzi7ne0EXAyFh1Ow10HIY+SIWHVhsIkS/mvNyUyW5TIPc22djWNQKf6OukOY2/htJpolj4l/uhPGe4BoFiV8m2jvyKq0X7truazc9/BDrLKkoIVIkXb0PenVs1AlFLnXzLEu9Lj4kxfkRO4zdV4CMHYWLWLLP9Dj0/Xg+tj9n/QX/IWVVrBporKiJgg99WztKw7wQ/Zd+Syu8vfa6IjpgRojtOiCb8MUvEUHcs8RG/PPRACJ8bNwCaNc0RNLoyfVGjjZGFh95XPr6huJYmn/11j45GTB9I5w77JnF83AWwAPyx15z6yHKm4epzXJ9yFrTK5nATQGD1H2i8rdg4ZvsjFE4nxEYTWDTkk9nQdZs3n5Os+pUh8hyyjsa4Hh2yjmfcivcE/KzyP8JH15OWH9QOHwdfRTDu3v4AxSZCuQKlhaSpYbHFahE+jqP+Pr0+Bc/e5ybu6SdAELlOJrVYU6pkgrvYJmkV6Ahfm3P8OZKt72MAGxDfdYNUA70QWMMC1YP+GQYedC+oLA4/BhQ1Su9AfUUdQGN0a8a6uaZFX5QyiA/6KrRUC06dQdXi9ZOCx8LY28Snl7TjgmOef15HnnmmQTbARJuR0eenprzOXJXJzkS6/Vx1ak/9gNRA8yMiVM9lIilsCAwEAAQ==";
 
   const VerificationErrorCode = Object.freeze({
+    MISSING_PUBLIC_KEY: "missing-public-key",
     MISSING_SIGNATURE: "missing-signature",
+    INVALID_PUBLIC_KEY: "invalid-public-key",
     INVALID_SIGNATURE: "invalid-signature",
     INVALID_LAUNCHER_HEADER: "invalid-launcher-header",
     INVALID_ZIP: "invalid-zip",
@@ -62,10 +65,21 @@
   async function verifyHmclFile(file) {
     const fileBuffer = await file.arrayBuffer();
     const entries = readZipEntries(fileBuffer);
+    const publicKeyEntry = entries.find((entry) => entry.name === PUBLIC_KEY_ENTRY_NAME);
     const signatureEntry = entries.find((entry) => entry.name === SIGNATURE_ENTRY_NAME);
+
+    if (!publicKeyEntry) {
+      throw new VerificationError(VerificationErrorCode.MISSING_PUBLIC_KEY, `missing ${PUBLIC_KEY_ENTRY_NAME}`);
+    }
 
     if (!signatureEntry) {
       throw new VerificationError(VerificationErrorCode.MISSING_SIGNATURE, `missing ${SIGNATURE_ENTRY_NAME}`);
+    }
+
+    const publicKeyDer = new Uint8Array(base64ToArrayBuffer(PUBLIC_KEY_DER_BASE64));
+    const bundledPublicKey = await readEntryContent(fileBuffer, publicKeyEntry);
+    if (!bytesEqual(bundledPublicKey, publicKeyDer)) {
+      throw new VerificationError(VerificationErrorCode.INVALID_PUBLIC_KEY, "public key mismatch");
     }
 
     const signature = await readEntryContent(fileBuffer, signatureEntry);
@@ -91,7 +105,7 @@
 
     const publicKey = await crypto.subtle.importKey(
       "spki",
-      base64ToArrayBuffer(PUBLIC_KEY_DER_BASE64),
+      publicKeyDer,
       {
         name: "RSASSA-PKCS1-v1_5",
         hash: "SHA-512",
@@ -365,9 +379,13 @@
 
   function formatVerificationError(error) {
     switch (error && error.code) {
-      case VerificationErrorCode.MISSING_SIGNATURE:
-        return "这个文件没有 HMCL 官方签名。";
+      case VerificationErrorCode.MISSING_PUBLIC_KEY:
+        return "这不是可验证的 HMCL 文件，或者 HMCL 版本过低，无法验证。";
 
+      case VerificationErrorCode.MISSING_SIGNATURE:
+        return "这是非官方构建，请谨慎甄别其来源。";
+
+      case VerificationErrorCode.INVALID_PUBLIC_KEY:
       case VerificationErrorCode.INVALID_SIGNATURE:
       case VerificationErrorCode.INVALID_LAUNCHER_HEADER:
         return "该 HMCL 文件可能被篡改或已损坏，请不要使用此文件。你可以从 HMCL 官方网站重新下载 HMCL。";


### PR DESCRIPTION
本 PR 添加了了一个新的页面，用于验证 HMCL 文件（jar/exe/sh）是否是官方构建。

我们可以在 QQ 群等场合让用户通过此页面自行对下载到的 HMCL 文件进行校验。