### PR TITLE
PR 预览构建时不再启用 webp 依赖

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -11,7 +11,6 @@ concurrency:
   cancel-in-progress: false
 env:
   JEKYLL_ENV: production
-  ENABLE_WEBP_AUTO_CONVERSION: "true"
   GITHUB_PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
 jobs:
   cache-refresh:


### PR DESCRIPTION
# PR 预览构建时不再启用 webp 依赖

当前 PR 预览构建流程会导致依赖安装失败，鉴于 webp 对预览构建意义不大，因此不再启用 webp 依赖。
